### PR TITLE
Initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 -->
 
-This is `terraform-aws-helm-release` project creates a helm chart with an option to create an EKS IAM role.
+This `terraform-aws-helm-release` module creates a helm chart with an option to create an EKS IAM role.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ No resources.
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not yet exist. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_dependency_update"></a> [dependency\_update](#input\_dependency\_update) | Runs helm dependency update before installing the chart. Defaults to `false`. | `bool` | `null` | no |
-| <a name="input_description"></a> [description](#input\_description) | Set release description attribute (visible in the history). | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | Release description attribute (visible in the history). | `string` | `null` | no |
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
@@ -180,7 +180,7 @@ No resources.
 | <a name="input_iam_role_enabled"></a> [iam\_role\_enabled](#input\_iam\_role\_enabled) | Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module. | `bool` | `false` | no |
 | <a name="input_iam_source_json_url"></a> [iam\_source\_json\_url](#input\_iam\_source\_json\_url) | IAM source json policy to download. This will be used as the `source_json` meaning the `var.iam_policy_statements` and `var.iam_policy_statements_template_path` can override it. | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_keyring"></a> [keyring](#input\_keyring) | Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home` | `string` | `null` | no |
+| <a name="input_keyring"></a> [keyring](#input\_keyring) | Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`. | `string` | `null` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | The namespace to install the release into. Defaults to `default`. | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
@@ -195,9 +195,9 @@ No resources.
 | <a name="input_render_subchart_notes"></a> [render\_subchart\_notes](#input\_render\_subchart\_notes) | If set, render subchart notes along with the parent. Defaults to `true`. | `bool` | `null` | no |
 | <a name="input_replace"></a> [replace](#input\_replace) | Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | Repository URL where to locate the requested chart. | `string` | `null` | no |
-| <a name="input_repository_ca_file"></a> [repository\_ca\_file](#input\_repository\_ca\_file) | The Repositories CA File. | `string` | `null` | no |
-| <a name="input_repository_cert_file"></a> [repository\_cert\_file](#input\_repository\_cert\_file) | The repositories cert file | `string` | `null` | no |
-| <a name="input_repository_key_file"></a> [repository\_key\_file](#input\_repository\_key\_file) | The repositories cert key file | `string` | `null` | no |
+| <a name="input_repository_ca_file"></a> [repository\_ca\_file](#input\_repository\_ca\_file) | The Repositories CA file. | `string` | `null` | no |
+| <a name="input_repository_cert_file"></a> [repository\_cert\_file](#input\_repository\_cert\_file) | The repositories cert file. | `string` | `null` | no |
+| <a name="input_repository_key_file"></a> [repository\_key\_file](#input\_repository\_key\_file) | The repositories cert key file. | `string` | `null` | no |
 | <a name="input_repository_password"></a> [repository\_password](#input\_repository\_password) | Password for HTTP basic authentication against the repository. | `string` | `null` | no |
 | <a name="input_repository_username"></a> [repository\_username](#input\_repository\_username) | Username for HTTP basic authentication against the repository. | `string` | `null` | no |
 | <a name="input_reset_values"></a> [reset\_values](#input\_reset\_values) | When upgrading, reset the values to the ones built into the chart. Defaults to `false`. | `bool` | `null` | no |
@@ -209,7 +209,7 @@ No resources.
 | <a name="input_skip_crds"></a> [skip\_crds](#input\_skip\_crds) | If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds | `number` | `null` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds. | `number` | `null` | no |
 | <a name="input_values"></a> [values](#input\_values) | List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options. | `any` | `null` | no |
 | <a name="input_verify"></a> [verify](#input\_verify) | Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_wait"></a> [wait](#input\_wait) | Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`. | `bool` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Available targets:
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_atomic"></a> [atomic](#input\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_aws_account_number"></a> [aws\_account\_number](#input\_aws\_account\_number) | AWS account number of EKS cluster owner | `string` | `null` | no |
+| <a name="input_aws_account_number"></a> [aws\_account\_number](#input\_aws\_account\_number) | AWS account number of EKS cluster owner. | `string` | `null` | no |
 | <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | AWS partition: `aws`, `aws-cn`, or `aws-us-gov`. Applicable when `var.iam_role_enabled` is `true`. | `string` | `"aws"` | no |
 | <a name="input_chart"></a> [chart](#input\_chart) | Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended. | `string` | n/a | yes |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Specify the exact chart version to install. If this is not specified, the latest version is installed. | `string` | `null` | no |
@@ -213,7 +213,7 @@ Available targets:
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
-| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted) | `string` | `""` | no |
+| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted). | `string` | `""` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-example-module [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-example-module.svg)](https://github.com/cloudposse/terraform-example-module/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com) [![Discourse Forum](https://img.shields.io/discourse/https/ask.sweetops.com/posts.svg)](https://ask.sweetops.com/)
 <!-- markdownlint-restore -->
@@ -30,7 +31,6 @@
 This is `terraform-example-module` project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
 use when creating new repositories.
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -55,7 +55,6 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
-
 
 
 
@@ -102,7 +101,7 @@ For automated tests of the complete example using [bats](https://github.com/bats
 
 ```hcl
 module "example" {
-  source = "https://github.com/cloudposse/terraform-example-module.git?ref=master"
+  source  = "cloudposse/terraform-helm-release/aws
   example = "Hello world!"
 }
 ```
@@ -134,45 +133,93 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| local | >= 1.2 |
-| random | >= 2.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| random | >= 2.2 |
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | git::https://github.com/cloudposse/terraform-aws-iam-policy.git | n/a |
+| <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.8.0 |
+| <a name="module_helm_release"></a> [helm\_release](#module\_helm\_release) | git::https://github.com/cloudposse/terraform-helm-release.git | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+No resources.
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| example | Example variable | `string` | `"hello world"` | no |
-| id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_atomic"></a> [atomic](#input\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_aws_account_number"></a> [aws\_account\_number](#input\_aws\_account\_number) | AWS account number of EKS cluster owner | `string` | `null` | no |
+| <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | AWS partition: `aws`, `aws-cn`, or `aws-us-gov`. Applicable when `var.iam_role_enabled` is `true`. | `string` | `"aws"` | no |
+| <a name="input_chart"></a> [chart](#input\_chart) | Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended. | `string` | n/a | yes |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Specify the exact chart version to install. If this is not specified, the latest version is installed. | `string` | `null` | no |
+| <a name="input_cleanup_on_fail"></a> [cleanup\_on\_fail](#input\_cleanup\_on\_fail) | Allow deletion of new resources created in this upgrade when upgrade fails. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not yet exist. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_dependency_update"></a> [dependency\_update](#input\_dependency\_update) | Runs helm dependency update before installing the chart. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | Set release description attribute (visible in the history). | `string` | `null` | no |
+| <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
+| <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted) | `string` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_iam_policy_statements"></a> [iam\_policy\_statements](#input\_iam\_policy\_statements) | IAM policy for the service account. Required if `var.iam_role_enabled` is `true`. This will not do variable replacements. Please see `var.iam_policy_statements_template_path`. | `any` | `{}` | no |
+| <a name="input_iam_role_enabled"></a> [iam\_role\_enabled](#input\_iam\_role\_enabled) | Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module. | `bool` | `false` | no |
+| <a name="input_iam_source_json_url"></a> [iam\_source\_json\_url](#input\_iam\_source\_json\_url) | IAM source json policy to download. This will be used as the `source_json` meaning the `var.iam_policy_statements` and `var.iam_policy_statements_template_path` can override it. | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_keyring"></a> [keyring](#input\_keyring) | Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home` | `string` | `null` | no |
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | The namespace to install the release into. Defaults to `default`. | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_lint"></a> [lint](#input\_lint) | Run the helm chart linter during the plan. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_max_history"></a> [max\_history](#input\_max\_history) | Maximum number of release versions stored per release. Defaults to `0` (no limit). | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_postrender_binary_path"></a> [postrender\_binary\_path](#input\_postrender\_binary\_path) | Relative or full path to command binary. | `string` | `null` | no |
+| <a name="input_recreate_pods"></a> [recreate\_pods](#input\_recreate\_pods) | Perform pods restart during upgrade/rollback. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_render_subchart_notes"></a> [render\_subchart\_notes](#input\_render\_subchart\_notes) | If set, render subchart notes along with the parent. Defaults to `true`. | `bool` | `null` | no |
+| <a name="input_replace"></a> [replace](#input\_replace) | Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_repository"></a> [repository](#input\_repository) | Repository URL where to locate the requested chart. | `string` | `null` | no |
+| <a name="input_repository_ca_file"></a> [repository\_ca\_file](#input\_repository\_ca\_file) | The Repositories CA File. | `string` | `null` | no |
+| <a name="input_repository_cert_file"></a> [repository\_cert\_file](#input\_repository\_cert\_file) | The repositories cert file | `string` | `null` | no |
+| <a name="input_repository_key_file"></a> [repository\_key\_file](#input\_repository\_key\_file) | The repositories cert key file | `string` | `null` | no |
+| <a name="input_repository_password"></a> [repository\_password](#input\_repository\_password) | Password for HTTP basic authentication against the repository. | `string` | `null` | no |
+| <a name="input_repository_username"></a> [repository\_username](#input\_repository\_username) | Username for HTTP basic authentication against the repository. | `string` | `null` | no |
+| <a name="input_reset_values"></a> [reset\_values](#input\_reset\_values) | When upgrading, reset the values to the ones built into the chart. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_reuse_values"></a> [reuse\_values](#input\_reuse\_values) | When upgrading, reuse the last release's values and merge in any overrides. If `reset_values` is specified, this is ignored. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | Kubernetes ServiceAccount name. Required if `var.iam_role_enabled` is `true`. | `string` | `null` | no |
+| <a name="input_service_account_namespace"></a> [service\_account\_namespace](#input\_service\_account\_namespace) | Kubernetes Namespace where service account is deployed. Required if `var.iam_role_enabled` is `true`. | `string` | `null` | no |
+| <a name="input_set"></a> [set](#input\_set) | Value block with custom values to be merged with the values yaml. | <pre>list(object({<br>    name  = string<br>    value = string<br>    type  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_set_sensitive"></a> [set\_sensitive](#input\_set\_sensitive) | Value block with custom sensitive values to be merged with the values yaml that won't be exposed in the plan's diff. | <pre>list(object({<br>    name  = string<br>    value = string<br>    type  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_skip_crds"></a> [skip\_crds](#input\_skip\_crds) | If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds | `number` | `null` | no |
+| <a name="input_values"></a> [values](#input\_values) | List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options. | `any` | `null` | no |
+| <a name="input_verify"></a> [verify](#input\_verify) | Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_wait"></a> [wait](#input\_wait) | Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`. | `bool` | `null` | no |
+| <a name="input_wait_for_jobs"></a> [wait\_for\_jobs](#input\_wait\_for\_jobs) | If wait is enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as `timeout`. Defaults to `false`. | `bool` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| example | Example output |
-| id | ID of the created example |
-| random | Stable random number for this example |
-
+| <a name="output_metadata"></a> [metadata](#output\_metadata) | Block status of the deployed release. |
 <!-- markdownlint-restore -->
 
 
@@ -184,13 +231,12 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
 
 - [terraform-null-label](https://github.com/cloudposse/terraform-null-label) - Terraform module designed to generate consistent names and tags for resources. Use terraform-null-label to implement a strict naming convention.
-
-
 
 
 ## References
@@ -275,7 +321,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 
@@ -335,12 +381,14 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] |
-|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
+|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@
 
 -->
 
-This is `terraform-aws-helm-release` project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
-use when creating new repositories.
+This is `terraform-aws-helm-release` project creates a helm chart with an option to create an EKS IAM role.
 
 ---
 
@@ -100,17 +99,19 @@ For automated tests of the complete example using [bats](https://github.com/bats
 (which tests and deploys the example on AWS), see [test](test).
 
 ```hcl
-module "aws_helm_release" {
+module "helm_release" {
   source  = "cloudposse/helm-release/aws"
   # Cloud Posse recommends pinning every module to a specific version
   # version = "x.x.x"
+
+  name = "echo"
 
   repository    = "https://charts.helm.sh/incubator"
   chart         = "raw"
   chart_version = "0.2.5"
 
-  kubernetes_namespace = "echo"
   create_namespace     = true
+  kubernetes_namespace = "echo"
 
   atomic          = true
   cleanup_on_fail = true
@@ -170,10 +171,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.2 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.2 |
 
 ## Modules
 
@@ -181,12 +185,13 @@ No providers.
 |------|--------|---------|
 | <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | cloudposse/iam-policy/aws | 0.1.0 |
 | <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.8.0 |
-| <a name="module_helm_release"></a> [helm\_release](#module\_helm\_release) | cloudposse/release/helm | 0.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 
 ## Inputs
 
@@ -256,6 +261,14 @@ No resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_metadata"></a> [metadata](#output\_metadata) | Block status of the deployed release. |
+| <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | Kubernetes Service Account name |
+| <a name="output_service_account_namespace"></a> [service\_account\_namespace](#output\_service\_account\_namespace) | Kubernetes Service Account namespace |
+| <a name="output_service_account_policy_arn"></a> [service\_account\_policy\_arn](#output\_service\_account\_policy\_arn) | IAM policy ARN |
+| <a name="output_service_account_policy_id"></a> [service\_account\_policy\_id](#output\_service\_account\_policy\_id) | IAM policy ID |
+| <a name="output_service_account_policy_name"></a> [service\_account\_policy\_name](#output\_service\_account\_policy\_name) | IAM policy name |
+| <a name="output_service_account_role_arn"></a> [service\_account\_role\_arn](#output\_service\_account\_role\_arn) | IAM role ARN |
+| <a name="output_service_account_role_name"></a> [service\_account\_role\_name](#output\_service\_account\_role\_name) | IAM role name |
+| <a name="output_service_account_role_unique_id"></a> [service\_account\_role\_unique\_id](#output\_service\_account\_role\_unique\_id) | IAM role unique ID |
 <!-- markdownlint-restore -->
 
 
@@ -281,7 +294,6 @@ For additional context, refer to some of these links.
 
 - [Terraform Standard Module Structure](https://www.terraform.io/docs/modules/index.html#standard-module-structure) - HashiCorp's standard module structure is a file and directory layout we recommend for reusable modules distributed in separate repositories.
 - [Terraform Module Requirements](https://www.terraform.io/docs/registry/modules/publish.html#requirements) - HashiCorp's guidance on all the requirements for publishing a module. Meeting the requirements for publishing a module is extremely easy.
-- [Terraform `random_integer` Resource](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) - The resource random_integer generates random values from a given range, described by the min and max attributes of a given resource.
 - [Terraform Version Pinning](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version) - The required_version setting can be used to constrain which versions of the Terraform CLI can be used with your configuration
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <!-- markdownlint-disable -->
-# terraform-example-module [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-example-module.svg)](https://github.com/cloudposse/terraform-example-module/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com) [![Discourse Forum](https://img.shields.io/discourse/https/ask.sweetops.com/posts.svg)](https://ask.sweetops.com/)
+# terraform-aws-helm-release [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-helm-release.svg)](https://github.com/cloudposse/terraform-aws-helm-release/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com) [![Discourse Forum](https://img.shields.io/discourse/https/ask.sweetops.com/posts.svg)](https://ask.sweetops.com/)
 <!-- markdownlint-restore -->
 
 [![README Header][readme_header_img]][readme_header_link]
@@ -28,7 +28,7 @@
 
 -->
 
-This is `terraform-example-module` project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
+This is `terraform-aws-helm-release` project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
 use when creating new repositories.
 
 ---
@@ -67,16 +67,16 @@ Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leadin
 
 | Benchmark | Description |
 |--------|---------------|
-| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
-| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
-| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
-| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
-| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
-| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
-| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
-| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=SOC2)| Service Organization Control 2 Compliance |
-| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
-| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-example-module/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-example-module&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-helm-release/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-helm-release&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
 
 
 
@@ -148,7 +148,7 @@ module "aws_helm_release" {
 ## Examples
 
 Here is an example of using this module:
-- [`examples/complete`](https://github.com/cloudposse/terraform-example-module/) - complete example of using this module
+- [`examples/complete`](https://github.com/cloudposse/terraform-aws-helm-release/) - complete example of using this module
 
 
 
@@ -262,7 +262,7 @@ No resources.
 
 ## Share the Love
 
-Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-example-module)! (it helps us **a lot**)
+Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-helm-release)! (it helps us **a lot**)
 
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
@@ -289,7 +289,7 @@ For additional context, refer to some of these links.
 
 **Got a question?** We got answers.
 
-File a GitHub [issue](https://github.com/cloudposse/terraform-example-module/issues), send us an [email][email] or join our [Slack Community][slack].
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-helm-release/issues), send us an [email][email] or join our [Slack Community][slack].
 
 [![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
 
@@ -337,7 +337,7 @@ Sign up for [our newsletter][newsletter] that covers everything on our technolog
 
 ### Bug Reports & Feature Requests
 
-Please use the [issue tracker](https://github.com/cloudposse/terraform-example-module/issues) to report any bugs or file feature requests.
+Please use the [issue tracker](https://github.com/cloudposse/terraform-aws-helm-release/issues) to report any bugs or file feature requests.
 
 ### Developing
 
@@ -430,32 +430,32 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 [![Beacon][beacon]][website]
 
   [logo]: https://cloudposse.com/logo-300x69.svg
-  [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=docs
-  [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=website
-  [github]: https://cpco.io/github?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=github
-  [jobs]: https://cpco.io/jobs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=jobs
-  [hire]: https://cpco.io/hire?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=hire
-  [slack]: https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=slack
-  [linkedin]: https://cpco.io/linkedin?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=linkedin
-  [twitter]: https://cpco.io/twitter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=twitter
-  [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=testimonial
-  [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=office_hours
-  [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=newsletter
-  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=discourse
-  [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=email
-  [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=commercial_support
-  [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=we_love_open_source
-  [terraform_modules]: https://cpco.io/terraform-modules?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=terraform_modules
+  [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=docs
+  [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=website
+  [github]: https://cpco.io/github?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=github
+  [jobs]: https://cpco.io/jobs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=jobs
+  [hire]: https://cpco.io/hire?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=hire
+  [slack]: https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=slack
+  [linkedin]: https://cpco.io/linkedin?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=linkedin
+  [twitter]: https://cpco.io/twitter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=twitter
+  [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=testimonial
+  [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=office_hours
+  [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=discourse
+  [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=email
+  [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=commercial_support
+  [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=we_love_open_source
+  [terraform_modules]: https://cpco.io/terraform-modules?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=terraform_modules
   [readme_header_img]: https://cloudposse.com/readme/header/img
-  [readme_header_link]: https://cloudposse.com/readme/header/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=readme_header_link
+  [readme_header_link]: https://cloudposse.com/readme/header/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=readme_header_link
   [readme_footer_img]: https://cloudposse.com/readme/footer/img
-  [readme_footer_link]: https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=readme_footer_link
+  [readme_footer_link]: https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=readme_footer_link
   [readme_commercial_support_img]: https://cloudposse.com/readme/commercial-support/img
-  [readme_commercial_support_link]: https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-example-module&utm_content=readme_commercial_support_link
-  [share_twitter]: https://twitter.com/intent/tweet/?text=terraform-example-module&url=https://github.com/cloudposse/terraform-example-module
-  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=terraform-example-module&url=https://github.com/cloudposse/terraform-example-module
-  [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudposse/terraform-example-module
-  [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudposse/terraform-example-module
-  [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-example-module
-  [share_email]: mailto:?subject=terraform-example-module&body=https://github.com/cloudposse/terraform-example-module
-  [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-example-module?pixel&cs=github&cm=readme&an=terraform-example-module
+  [readme_commercial_support_link]: https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-helm-release&utm_content=readme_commercial_support_link
+  [share_twitter]: https://twitter.com/intent/tweet/?text=terraform-aws-helm-release&url=https://github.com/cloudposse/terraform-aws-helm-release
+  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=terraform-aws-helm-release&url=https://github.com/cloudposse/terraform-aws-helm-release
+  [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudposse/terraform-aws-helm-release
+  [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudposse/terraform-aws-helm-release
+  [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-helm-release
+  [share_email]: mailto:?subject=terraform-aws-helm-release&body=https://github.com/cloudposse/terraform-aws-helm-release
+  [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-helm-release?pixel&cs=github&cm=readme&an=terraform-aws-helm-release

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Available targets:
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
-| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted) | `string` | `null` | no |
+| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted) | `string` | `""` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -100,9 +100,45 @@ For automated tests of the complete example using [bats](https://github.com/bats
 (which tests and deploys the example on AWS), see [test](test).
 
 ```hcl
-module "example" {
-  source  = "cloudposse/terraform-helm-release/aws
-  example = "Hello world!"
+module "aws_helm_release" {
+  source  = "cloudposse/helm-release/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version = "x.x.x"
+
+  repository    = "https://charts.helm.sh/incubator"
+  chart         = "raw"
+  chart_version = "0.2.5"
+
+  kubernetes_namespace = "echo"
+  create_namespace     = true
+
+  atomic          = true
+  cleanup_on_fail = true
+  timeout         = 300
+  wait            = true
+
+  # these values will be deep merged
+  # values = [
+  # ]
+
+  iam_role_enabled = true
+
+  iam_policy_statements = [
+    {
+      sid        = "ListMyBucket"
+      effect     = "Allow"
+      actions    = ["s3:ListBucket"]
+      resources  = ["arn:aws:s3:::test"]
+      conditions = []
+    },
+    {
+      sid        = "WriteMyBucket"
+      effect     = "Allow"
+      actions    = ["s3:PutObject", "s3:GetObject", "s3:DeleteObject"]
+      resources  = ["arn:aws:s3:::test/*"]
+      conditions = []
+    },
+  ]
 }
 ```
 
@@ -143,9 +179,9 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | git::https://github.com/cloudposse/terraform-aws-iam-policy.git | n/a |
+| <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | cloudposse/iam-policy/aws | 0.1.0 |
 | <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.8.0 |
-| <a name="module_helm_release"></a> [helm\_release](#module\_helm\_release) | git::https://github.com/cloudposse/terraform-helm-release.git | n/a |
+| <a name="module_helm_release"></a> [helm\_release](#module\_helm\_release) | cloudposse/release/helm | 0.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources

--- a/README.yaml
+++ b/README.yaml
@@ -48,17 +48,13 @@ references:
   - name: "Terraform Module Requirements"
     description: "HashiCorp's guidance on all the requirements for publishing a module. Meeting the requirements for publishing a module is extremely easy."
     url: "https://www.terraform.io/docs/registry/modules/publish.html#requirements"
-  - name: "Terraform `random_integer` Resource"
-    description: "The resource random_integer generates random values from a given range, described by the min and max attributes of a given resource."
-    url: "https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer"
   - name: "Terraform Version Pinning"
     description: "The required_version setting can be used to constrain which versions of the Terraform CLI can be used with your configuration"
     url: "https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version"
 
 # Short description of this project
 description: |-
-  This is `terraform-aws-helm-release` project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
-  use when creating new repositories.
+  This is `terraform-aws-helm-release` project creates a helm chart with an option to create an EKS IAM role.
 
 # Introduction to the project
 #introduction: |-
@@ -72,17 +68,19 @@ usage: |-
   (which tests and deploys the example on AWS), see [test](test).
 
   ```hcl
-  module "aws_helm_release" {
+  module "helm_release" {
     source  = "cloudposse/helm-release/aws"
     # Cloud Posse recommends pinning every module to a specific version
     # version = "x.x.x"
+
+    name = "echo"
 
     repository    = "https://charts.helm.sh/incubator"
     chart         = "raw"
     chart_version = "0.2.5"
 
-    kubernetes_namespace = "echo"
     create_namespace     = true
+    kubernetes_namespace = "echo"
 
     atomic          = true
     cleanup_on_fail = true

--- a/README.yaml
+++ b/README.yaml
@@ -67,14 +67,50 @@ description: |-
 # How to use this module. Should be an easy example to copy and paste.
 usage: |-
   For a complete example, see [examples/complete](examples/complete).
-  
+
   For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest)
   (which tests and deploys the example on AWS), see [test](test).
 
   ```hcl
-  module "example" {
-    source  = "cloudposse/terraform-helm-release/aws
-    example = "Hello world!"
+  module "aws_helm_release" {
+    source  = "cloudposse/helm-release/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
+
+    repository    = "https://charts.helm.sh/incubator"
+    chart         = "raw"
+    chart_version = "0.2.5"
+
+    kubernetes_namespace = "echo"
+    create_namespace     = true
+
+    atomic          = true
+    cleanup_on_fail = true
+    timeout         = 300
+    wait            = true
+
+    # these values will be deep merged
+    # values = [
+    # ]
+
+    iam_role_enabled = true
+
+    iam_policy_statements = [
+      {
+        sid        = "ListMyBucket"
+        effect     = "Allow"
+        actions    = ["s3:ListBucket"]
+        resources  = ["arn:aws:s3:::test"]
+        conditions = []
+      },
+      {
+        sid        = "WriteMyBucket"
+        effect     = "Allow"
+        actions    = ["s3:PutObject", "s3:GetObject", "s3:DeleteObject"]
+        resources  = ["arn:aws:s3:::test/*"]
+        conditions = []
+      },
+    ]
   }
   ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -17,7 +17,7 @@ license: "APACHE2"
 copyrights:
   - name: "Cloud Posse, LLC"
     url: "https://cloudposse.com"
-    year: "2020"
+    year: "2021"
 
 # Canonical GitHub repo
 github_repo: cloudposse/terraform-example-module
@@ -73,7 +73,7 @@ usage: |-
 
   ```hcl
   module "example" {
-    source = "https://github.com/cloudposse/terraform-example-module.git?ref=master"
+    source  = "cloudposse/terraform-helm-release/aws
     example = "Hello world!"
   }
   ```
@@ -96,3 +96,5 @@ include:
 contributors:
   - name: "Erik Osterman"
     github: "osterman"
+  - name: "RB"
+    github: "nitrocode"

--- a/README.yaml
+++ b/README.yaml
@@ -54,7 +54,7 @@ references:
 
 # Short description of this project
 description: |-
-  This is `terraform-aws-helm-release` project creates a helm chart with an option to create an EKS IAM role.
+  This `terraform-aws-helm-release` module creates a helm chart with an option to create an EKS IAM role.
 
 # Introduction to the project
 #introduction: |-

--- a/README.yaml
+++ b/README.yaml
@@ -5,7 +5,7 @@
 #
 
 # Name of this project
-name: terraform-example-module
+name: terraform-aws-helm-release
 
 # Logo for this project
 #logo: docs/logo.png
@@ -20,13 +20,13 @@ copyrights:
     year: "2021"
 
 # Canonical GitHub repo
-github_repo: cloudposse/terraform-example-module
+github_repo: cloudposse/terraform-aws-helm-release
 
 # Badges to display
 badges:
   - name: "Latest Release"
-    image: "https://img.shields.io/github/release/cloudposse/terraform-example-module.svg"
-    url: "https://github.com/cloudposse/terraform-example-module/releases/latest"
+    image: "https://img.shields.io/github/release/cloudposse/terraform-aws-helm-release.svg"
+    url: "https://github.com/cloudposse/terraform-aws-helm-release/releases/latest"
   - name: "Slack Community"
     image: "https://slack.cloudposse.com/badge.svg"
     url: "https://slack.cloudposse.com"
@@ -57,7 +57,7 @@ references:
 
 # Short description of this project
 description: |-
-  This is `terraform-example-module` project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
+  This is `terraform-aws-helm-release` project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
   use when creating new repositories.
 
 # Introduction to the project
@@ -117,7 +117,7 @@ usage: |-
 # Example usage
 examples: |-
   Here is an example of using this module:
-  - [`examples/complete`](https://github.com/cloudposse/terraform-example-module/) - complete example of using this module
+  - [`examples/complete`](https://github.com/cloudposse/terraform-aws-helm-release/) - complete example of using this module
 
 # How to get started quickly
 #quickstart: |-

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,43 +3,91 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| local | >= 1.2 |
-| random | >= 2.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| random | >= 2.2 |
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | git::https://github.com/cloudposse/terraform-aws-iam-policy.git | n/a |
+| <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.8.0 |
+| <a name="module_helm_release"></a> [helm\_release](#module\_helm\_release) | git::https://github.com/cloudposse/terraform-helm-release.git | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+No resources.
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| example | Example variable | `string` | `"hello world"` | no |
-| id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_atomic"></a> [atomic](#input\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_aws_account_number"></a> [aws\_account\_number](#input\_aws\_account\_number) | AWS account number of EKS cluster owner | `string` | `null` | no |
+| <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | AWS partition: `aws`, `aws-cn`, or `aws-us-gov`. Applicable when `var.iam_role_enabled` is `true`. | `string` | `"aws"` | no |
+| <a name="input_chart"></a> [chart](#input\_chart) | Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended. | `string` | n/a | yes |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Specify the exact chart version to install. If this is not specified, the latest version is installed. | `string` | `null` | no |
+| <a name="input_cleanup_on_fail"></a> [cleanup\_on\_fail](#input\_cleanup\_on\_fail) | Allow deletion of new resources created in this upgrade when upgrade fails. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not yet exist. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_dependency_update"></a> [dependency\_update](#input\_dependency\_update) | Runs helm dependency update before installing the chart. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | Set release description attribute (visible in the history). | `string` | `null` | no |
+| <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
+| <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted) | `string` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_iam_policy_statements"></a> [iam\_policy\_statements](#input\_iam\_policy\_statements) | IAM policy for the service account. Required if `var.iam_role_enabled` is `true`. This will not do variable replacements. Please see `var.iam_policy_statements_template_path`. | `any` | `{}` | no |
+| <a name="input_iam_role_enabled"></a> [iam\_role\_enabled](#input\_iam\_role\_enabled) | Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module. | `bool` | `false` | no |
+| <a name="input_iam_source_json_url"></a> [iam\_source\_json\_url](#input\_iam\_source\_json\_url) | IAM source json policy to download. This will be used as the `source_json` meaning the `var.iam_policy_statements` and `var.iam_policy_statements_template_path` can override it. | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_keyring"></a> [keyring](#input\_keyring) | Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home` | `string` | `null` | no |
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | The namespace to install the release into. Defaults to `default`. | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_lint"></a> [lint](#input\_lint) | Run the helm chart linter during the plan. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_max_history"></a> [max\_history](#input\_max\_history) | Maximum number of release versions stored per release. Defaults to `0` (no limit). | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_postrender_binary_path"></a> [postrender\_binary\_path](#input\_postrender\_binary\_path) | Relative or full path to command binary. | `string` | `null` | no |
+| <a name="input_recreate_pods"></a> [recreate\_pods](#input\_recreate\_pods) | Perform pods restart during upgrade/rollback. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_render_subchart_notes"></a> [render\_subchart\_notes](#input\_render\_subchart\_notes) | If set, render subchart notes along with the parent. Defaults to `true`. | `bool` | `null` | no |
+| <a name="input_replace"></a> [replace](#input\_replace) | Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_repository"></a> [repository](#input\_repository) | Repository URL where to locate the requested chart. | `string` | `null` | no |
+| <a name="input_repository_ca_file"></a> [repository\_ca\_file](#input\_repository\_ca\_file) | The Repositories CA File. | `string` | `null` | no |
+| <a name="input_repository_cert_file"></a> [repository\_cert\_file](#input\_repository\_cert\_file) | The repositories cert file | `string` | `null` | no |
+| <a name="input_repository_key_file"></a> [repository\_key\_file](#input\_repository\_key\_file) | The repositories cert key file | `string` | `null` | no |
+| <a name="input_repository_password"></a> [repository\_password](#input\_repository\_password) | Password for HTTP basic authentication against the repository. | `string` | `null` | no |
+| <a name="input_repository_username"></a> [repository\_username](#input\_repository\_username) | Username for HTTP basic authentication against the repository. | `string` | `null` | no |
+| <a name="input_reset_values"></a> [reset\_values](#input\_reset\_values) | When upgrading, reset the values to the ones built into the chart. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_reuse_values"></a> [reuse\_values](#input\_reuse\_values) | When upgrading, reuse the last release's values and merge in any overrides. If `reset_values` is specified, this is ignored. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | Kubernetes ServiceAccount name. Required if `var.iam_role_enabled` is `true`. | `string` | `null` | no |
+| <a name="input_service_account_namespace"></a> [service\_account\_namespace](#input\_service\_account\_namespace) | Kubernetes Namespace where service account is deployed. Required if `var.iam_role_enabled` is `true`. | `string` | `null` | no |
+| <a name="input_set"></a> [set](#input\_set) | Value block with custom values to be merged with the values yaml. | <pre>list(object({<br>    name  = string<br>    value = string<br>    type  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_set_sensitive"></a> [set\_sensitive](#input\_set\_sensitive) | Value block with custom sensitive values to be merged with the values yaml that won't be exposed in the plan's diff. | <pre>list(object({<br>    name  = string<br>    value = string<br>    type  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_skip_crds"></a> [skip\_crds](#input\_skip\_crds) | If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds | `number` | `null` | no |
+| <a name="input_values"></a> [values](#input\_values) | List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options. | `any` | `null` | no |
+| <a name="input_verify"></a> [verify](#input\_verify) | Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_wait"></a> [wait](#input\_wait) | Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`. | `bool` | `null` | no |
+| <a name="input_wait_for_jobs"></a> [wait\_for\_jobs](#input\_wait\_for\_jobs) | If wait is enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as `timeout`. Defaults to `false`. | `bool` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| example | Example output |
-| id | ID of the created example |
-| random | Stable random number for this example |
-
+| <a name="output_metadata"></a> [metadata](#output\_metadata) | Block status of the deployed release. |
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,9 +13,9 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | git::https://github.com/cloudposse/terraform-aws-iam-policy.git | n/a |
+| <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | cloudposse/iam-policy/aws | 0.1.0 |
 | <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.8.0 |
-| <a name="module_helm_release"></a> [helm\_release](#module\_helm\_release) | git::https://github.com/cloudposse/terraform-helm-release.git | n/a |
+| <a name="module_helm_release"></a> [helm\_release](#module\_helm\_release) | cloudposse/release/helm | 0.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -38,7 +38,7 @@ No resources.
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not yet exist. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_dependency_update"></a> [dependency\_update](#input\_dependency\_update) | Runs helm dependency update before installing the chart. Defaults to `false`. | `bool` | `null` | no |
-| <a name="input_description"></a> [description](#input\_description) | Set release description attribute (visible in the history). | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | Release description attribute (visible in the history). | `string` | `null` | no |
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
@@ -50,7 +50,7 @@ No resources.
 | <a name="input_iam_role_enabled"></a> [iam\_role\_enabled](#input\_iam\_role\_enabled) | Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module. | `bool` | `false` | no |
 | <a name="input_iam_source_json_url"></a> [iam\_source\_json\_url](#input\_iam\_source\_json\_url) | IAM source json policy to download. This will be used as the `source_json` meaning the `var.iam_policy_statements` and `var.iam_policy_statements_template_path` can override it. | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_keyring"></a> [keyring](#input\_keyring) | Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home` | `string` | `null` | no |
+| <a name="input_keyring"></a> [keyring](#input\_keyring) | Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`. | `string` | `null` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | The namespace to install the release into. Defaults to `default`. | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
@@ -65,9 +65,9 @@ No resources.
 | <a name="input_render_subchart_notes"></a> [render\_subchart\_notes](#input\_render\_subchart\_notes) | If set, render subchart notes along with the parent. Defaults to `true`. | `bool` | `null` | no |
 | <a name="input_replace"></a> [replace](#input\_replace) | Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | Repository URL where to locate the requested chart. | `string` | `null` | no |
-| <a name="input_repository_ca_file"></a> [repository\_ca\_file](#input\_repository\_ca\_file) | The Repositories CA File. | `string` | `null` | no |
-| <a name="input_repository_cert_file"></a> [repository\_cert\_file](#input\_repository\_cert\_file) | The repositories cert file | `string` | `null` | no |
-| <a name="input_repository_key_file"></a> [repository\_key\_file](#input\_repository\_key\_file) | The repositories cert key file | `string` | `null` | no |
+| <a name="input_repository_ca_file"></a> [repository\_ca\_file](#input\_repository\_ca\_file) | The Repositories CA file. | `string` | `null` | no |
+| <a name="input_repository_cert_file"></a> [repository\_cert\_file](#input\_repository\_cert\_file) | The repositories cert file. | `string` | `null` | no |
+| <a name="input_repository_key_file"></a> [repository\_key\_file](#input\_repository\_key\_file) | The repositories cert key file. | `string` | `null` | no |
 | <a name="input_repository_password"></a> [repository\_password](#input\_repository\_password) | Password for HTTP basic authentication against the repository. | `string` | `null` | no |
 | <a name="input_repository_username"></a> [repository\_username](#input\_repository\_username) | Username for HTTP basic authentication against the repository. | `string` | `null` | no |
 | <a name="input_reset_values"></a> [reset\_values](#input\_reset\_values) | When upgrading, reset the values to the ones built into the chart. Defaults to `false`. | `bool` | `null` | no |
@@ -79,7 +79,7 @@ No resources.
 | <a name="input_skip_crds"></a> [skip\_crds](#input\_skip\_crds) | If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds | `number` | `null` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds. | `number` | `null` | no |
 | <a name="input_values"></a> [values](#input\_values) | List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options. | `any` | `null` | no |
 | <a name="input_verify"></a> [verify](#input\_verify) | Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_wait"></a> [wait](#input\_wait) | Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`. | `bool` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -46,7 +46,7 @@
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
-| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted) | `string` | `null` | no |
+| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted) | `string` | `""` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -33,7 +33,7 @@
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_atomic"></a> [atomic](#input\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_aws_account_number"></a> [aws\_account\_number](#input\_aws\_account\_number) | AWS account number of EKS cluster owner | `string` | `null` | no |
+| <a name="input_aws_account_number"></a> [aws\_account\_number](#input\_aws\_account\_number) | AWS account number of EKS cluster owner. | `string` | `null` | no |
 | <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | AWS partition: `aws`, `aws-cn`, or `aws-us-gov`. Applicable when `var.iam_role_enabled` is `true`. | `string` | `"aws"` | no |
 | <a name="input_chart"></a> [chart](#input\_chart) | Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended. | `string` | n/a | yes |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Specify the exact chart version to install. If this is not specified, the latest version is installed. | `string` | `null` | no |
@@ -46,7 +46,7 @@
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
-| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted) | `string` | `""` | no |
+| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted). | `string` | `""` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,10 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.2 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.2 |
 
 ## Modules
 
@@ -15,12 +18,13 @@ No providers.
 |------|--------|---------|
 | <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | cloudposse/iam-policy/aws | 0.1.0 |
 | <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.8.0 |
-| <a name="module_helm_release"></a> [helm\_release](#module\_helm\_release) | cloudposse/release/helm | 0.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 
 ## Inputs
 
@@ -90,4 +94,12 @@ No resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_metadata"></a> [metadata](#output\_metadata) | Block status of the deployed release. |
+| <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | Kubernetes Service Account name |
+| <a name="output_service_account_namespace"></a> [service\_account\_namespace](#output\_service\_account\_namespace) | Kubernetes Service Account namespace |
+| <a name="output_service_account_policy_arn"></a> [service\_account\_policy\_arn](#output\_service\_account\_policy\_arn) | IAM policy ARN |
+| <a name="output_service_account_policy_id"></a> [service\_account\_policy\_id](#output\_service\_account\_policy\_id) | IAM policy ID |
+| <a name="output_service_account_policy_name"></a> [service\_account\_policy\_name](#output\_service\_account\_policy\_name) | IAM policy name |
+| <a name="output_service_account_role_arn"></a> [service\_account\_role\_arn](#output\_service\_account\_role\_arn) | IAM role ARN |
+| <a name="output_service_account_role_name"></a> [service\_account\_role\_name](#output\_service\_account\_role\_name) | IAM role name |
+| <a name="output_service_account_role_unique_id"></a> [service\_account\_role\_unique\_id](#output\_service\_account\_role\_unique\_id) | IAM role unique ID |
 <!-- markdownlint-restore -->

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -36,20 +36,20 @@ cluster_encryption_config_enabled = true
 
 ## helm related
 
-repository    = "https://charts.helm.sh/incubator"
+repository = "https://charts.helm.sh/incubator"
 
-chart         = "raw"
+chart = "raw"
 
 chart_version = "0.2.5"
 
-create_namespace     = true
+create_namespace = true
 
 kubernetes_namespace = "echo"
 
-atomic          = true
+atomic = true
 
 cleanup_on_fail = true
 
-timeout         = 300
+timeout = 300
 
-wait            = true
+wait = true

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -6,5 +6,50 @@ environment = "ue2"
 
 stage = "test"
 
-name = "example"
+name = "helm"
 
+## eks related
+
+availability_zones = ["us-east-2a", "us-east-2b"]
+
+kubernetes_version = "1.19"
+
+oidc_provider_enabled = true
+
+enabled_cluster_log_types = ["audit"]
+
+cluster_log_retention_period = 7
+
+instance_types = ["t3.small"]
+
+desired_size = 2
+
+max_size = 3
+
+min_size = 2
+
+disk_size = 20
+
+kubernetes_labels = {}
+
+cluster_encryption_config_enabled = true
+
+## helm related
+
+repository    = "https://charts.helm.sh/incubator"
+
+chart         = "raw"
+
+chart_version = "0.2.5"
+
+create_namespace     = true
+
+kubernetes_namespace = "echo"
+
+atomic          = true
+
+cleanup_on_fail = true
+
+timeout         = 300
+
+wait            = true

--- a/examples/complete/main-eks.tf
+++ b/examples/complete/main-eks.tf
@@ -1,0 +1,111 @@
+provider "aws" {
+  region = var.region
+}
+
+module "label" {
+  source     = "cloudposse/label/null"
+  version    = "0.24.1"
+  attributes = ["cluster"]
+
+  context = module.this.context
+}
+
+locals {
+  # The usage of the specific kubernetes.io/cluster/* resource tags below are required
+  # for EKS and Kubernetes to discover and manage networking resources
+  # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
+  tags = merge(module.label.tags, { "kubernetes.io/cluster/${module.label.id}" = "shared" })
+
+  # Unfortunately, most_recent (https://github.com/cloudposse/terraform-aws-eks-workers/blob/34a43c25624a6efb3ba5d2770a601d7cb3c0d391/main.tf#L141)
+  # variable does not work as expected, if you are not going to use custom ami you should
+  # enforce usage of eks_worker_ami_name_filter variable to set the right kubernetes version for EKS workers,
+  # otherwise will be used the first version of Kubernetes supported by AWS (v1.11) for EKS workers but
+  # EKS control plane will use the version specified by kubernetes_version variable.
+  eks_worker_ami_name_filter = "amazon-eks-node-${var.kubernetes_version}*"
+
+  # required tags to make ALB ingress work https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+  public_subnets_additional_tags = {
+    "kubernetes.io/role/elb" : 1
+  }
+  private_subnets_additional_tags = {
+    "kubernetes.io/role/internal-elb" : 1
+  }
+}
+
+module "vpc" {
+  source  = "cloudposse/vpc/aws"
+  version = "0.21.1"
+
+  cidr_block = "172.16.0.0/16"
+  tags       = local.tags
+
+  context = module.this.context
+}
+
+module "subnets" {
+  source  = "cloudposse/dynamic-subnets/aws"
+  version = "0.38.0"
+
+  availability_zones              = var.availability_zones
+  vpc_id                          = module.vpc.vpc_id
+  igw_id                          = module.vpc.igw_id
+  cidr_block                      = module.vpc.vpc_cidr_block
+  nat_gateway_enabled             = true
+  nat_instance_enabled            = false
+  tags                            = local.tags
+  public_subnets_additional_tags  = local.public_subnets_additional_tags
+  private_subnets_additional_tags = local.private_subnets_additional_tags
+
+  context = module.this.context
+}
+
+module "eks_cluster" {
+  source  = "cloudposse/eks-cluster/aws"
+  version = "0.39.0"
+
+  region                       = var.region
+  vpc_id                       = module.vpc.vpc_id
+  subnet_ids                   = concat(module.subnets.private_subnet_ids, module.subnets.public_subnet_ids)
+  kubernetes_version           = var.kubernetes_version
+  local_exec_interpreter       = var.local_exec_interpreter
+  oidc_provider_enabled        = var.oidc_provider_enabled
+  enabled_cluster_log_types    = var.enabled_cluster_log_types
+  cluster_log_retention_period = var.cluster_log_retention_period
+
+  cluster_encryption_config_enabled                         = var.cluster_encryption_config_enabled
+  cluster_encryption_config_kms_key_id                      = var.cluster_encryption_config_kms_key_id
+  cluster_encryption_config_kms_key_enable_key_rotation     = var.cluster_encryption_config_kms_key_enable_key_rotation
+  cluster_encryption_config_kms_key_deletion_window_in_days = var.cluster_encryption_config_kms_key_deletion_window_in_days
+  cluster_encryption_config_kms_key_policy                  = var.cluster_encryption_config_kms_key_policy
+  cluster_encryption_config_resources                       = var.cluster_encryption_config_resources
+
+  context = module.this.context
+}
+
+# Ensure ordering of resource creation to eliminate the race conditions when applying the Kubernetes Auth ConfigMap.
+# Do not create Node Group before the EKS cluster is created and the `aws-auth` Kubernetes ConfigMap is applied.
+# Otherwise, EKS will create the ConfigMap first and add the managed node role ARNs to it,
+# and the kubernetes provider will throw an error that the ConfigMap already exists (because it can't update the map, only create it).
+# If we create the ConfigMap first (to add additional roles/users/accounts), EKS will just update it by adding the managed node role ARNs.
+data "null_data_source" "wait_for_cluster_and_kubernetes_configmap" {
+  inputs = {
+    cluster_name             = module.eks_cluster.eks_cluster_id
+    kubernetes_config_map_id = module.eks_cluster.kubernetes_config_map_id
+  }
+}
+
+module "eks_node_group" {
+  source  = "cloudposse/eks-node-group/aws"
+  version = "0.19.0"
+
+  subnet_ids        = module.subnets.private_subnet_ids
+  cluster_name      = data.null_data_source.wait_for_cluster_and_kubernetes_configmap.outputs["cluster_name"]
+  instance_types    = var.instance_types
+  desired_size      = var.desired_size
+  min_size          = var.min_size
+  max_size          = var.max_size
+  kubernetes_labels = var.kubernetes_labels
+  disk_size         = var.disk_size
+
+  context = module.this.context
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,7 +1,35 @@
-module "example" {
-  source = "../.."
+data "aws_eks_cluster_auth" "kubernetes" {
+  name = module.eks_cluster.eks_cluster_id
+}
 
-  example = var.example
+provider "helm" {
+  kubernetes {
+    host                   = module.eks_cluster.eks_cluster_endpoint
+    token                  = data.aws_eks_cluster_auth.kubernetes.token
+    cluster_ca_certificate = base64decode(module.eks_cluster.eks_cluster_certificate_authority_data)
+  }
+}
 
-  context = module.this.context
+module "helm_release" {
+  source = "../../"
+
+  # source  = "cloudposse/helm-release/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version = "x.x.x"
+
+  repository    = var.repository
+  chart         = var.chart
+  chart_version = var.chart_version
+
+  create_namespace     = var.create_namespace
+  kubernetes_namespace = var.kubernetes_namespace
+
+  atomic          = var.atomic
+  cleanup_on_fail = var.cleanup_on_fail
+  timeout         = var.timeout
+  wait            = var.wait
+
+  values = [
+    file("${path.module}/values.yaml")
+  ]
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,14 +1,48 @@
-output "id" {
-  description = "ID of the created example"
-  value       = module.example.id
+## eks_iam_role
+
+output "service_account_namespace" {
+  value       = module.helm_release.service_account_namespace
+  description = "Kubernetes Service Account namespace"
 }
 
-output "example" {
-  description = "Output \"example\" from example module"
-  value       = module.example.example
+output "service_account_name" {
+  value       = module.helm_release.service_account_name
+  description = "Kubernetes Service Account name"
 }
 
-output "random" {
-  description = "Output \"random\" from example module"
-  value       = module.example.random
+output "service_account_role_name" {
+  value       = module.helm_release.service_account_role_name
+  description = "IAM role name"
+}
+
+output "service_account_role_unique_id" {
+  value       = module.helm_release.service_account_role_unique_id
+  description = "IAM role unique ID"
+}
+
+output "service_account_role_arn" {
+  value       = module.helm_release.service_account_role_arn
+  description = "IAM role ARN"
+}
+
+output "service_account_policy_name" {
+  value       = module.helm_release.service_account_policy_name
+  description = "IAM policy name"
+}
+
+output "service_account_policy_id" {
+  value       = module.helm_release.service_account_policy_id
+  description = "IAM policy ID"
+}
+
+output "service_account_policy_arn" {
+  value       = module.helm_release.service_account_policy_arn
+  description = "IAM policy ARN"
+}
+
+## helm_release
+
+output "metadata" {
+  description = "Block status of the deployed release."
+  value       = module.helm_release.metadata
 }

--- a/examples/complete/values.yaml
+++ b/examples/complete/values.yaml
@@ -1,0 +1,39 @@
+image:
+  repository: "amazon/aws-node-termination-handler"
+  tag: "v1.13.1"
+  pullPolicy: IfNotPresent
+
+podMonitor:
+  create: false
+  interval: "30s"
+  sampleLimit: 5000
+
+priorityClassName: system-node-critical
+
+rbac:
+  pspEnabled: true
+
+resources:
+  requests:
+    memory: "64Mi"
+    cpu: "50m"
+  limits:
+    memory: "128Mi"
+    cpu: "100m"
+
+securityContext:
+  runAsUserID: 1000
+  runAsGroupID: 1000
+
+serviceAccount:
+  create: true
+  name: "aws-node-termination-handler"
+  annotations: {}
+
+tolerations:
+- operator: Exists
+
+updateStrategy:
+  type: "RollingUpdate"
+  rollingUpdate:
+    maxUnavailable: 1

--- a/examples/complete/variables-eks.tf
+++ b/examples/complete/variables-eks.tf
@@ -1,0 +1,136 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "List of availability zones"
+}
+
+variable "kubernetes_version" {
+  type        = string
+  default     = "1.17"
+  description = "Desired Kubernetes master version. If you do not specify a value, the latest available version is used"
+}
+
+variable "enabled_cluster_log_types" {
+  type        = list(string)
+  default     = []
+  description = "A list of the desired control plane logging to enable. For more information, see https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. Possible values [`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`]"
+}
+
+variable "cluster_log_retention_period" {
+  type        = number
+  default     = 0
+  description = "Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html."
+}
+
+variable "map_additional_aws_accounts" {
+  description = "Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap"
+  type        = list(string)
+  default     = []
+}
+
+variable "map_additional_iam_roles" {
+  description = "Additional IAM roles to add to `config-map-aws-auth` ConfigMap"
+
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+
+  default = []
+}
+
+variable "map_additional_iam_users" {
+  description = "Additional IAM users to add to `config-map-aws-auth` ConfigMap"
+
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+
+  default = []
+}
+
+variable "oidc_provider_enabled" {
+  type        = bool
+  default     = true
+  description = "Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using `kiam` or `kube2iam`. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html"
+}
+
+variable "local_exec_interpreter" {
+  type        = list(string)
+  default     = ["/bin/sh", "-c"]
+  description = "shell to use for local_exec"
+}
+
+variable "disk_size" {
+  type        = number
+  description = "Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided"
+}
+
+variable "instance_types" {
+  type        = list(string)
+  description = "Set of instance types associated with the EKS Node Group. Defaults to [\"t3.medium\"]. Terraform will only perform drift detection if a configuration value is provided"
+}
+
+variable "kubernetes_labels" {
+  type        = map(string)
+  description = "Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed"
+  default     = {}
+}
+
+variable "desired_size" {
+  type        = number
+  description = "Desired number of worker nodes"
+}
+
+variable "max_size" {
+  type        = number
+  description = "The maximum size of the AutoScaling Group"
+}
+
+variable "min_size" {
+  type        = number
+  description = "The minimum size of the AutoScaling Group"
+}
+
+variable "cluster_encryption_config_enabled" {
+  type        = bool
+  default     = true
+  description = "Set to `true` to enable Cluster Encryption Configuration"
+}
+
+variable "cluster_encryption_config_kms_key_id" {
+  type        = string
+  default     = ""
+  description = "KMS Key ID to use for cluster encryption config"
+}
+
+variable "cluster_encryption_config_kms_key_enable_key_rotation" {
+  type        = bool
+  default     = true
+  description = "Cluster Encryption Config KMS Key Resource argument - enable kms key rotation"
+}
+
+variable "cluster_encryption_config_kms_key_deletion_window_in_days" {
+  type        = number
+  default     = 10
+  description = "Cluster Encryption Config KMS Key Resource argument - key deletion windows in days post destruction"
+}
+
+variable "cluster_encryption_config_kms_key_policy" {
+  type        = string
+  default     = null
+  description = "Cluster Encryption Config KMS Key Resource argument - key policy"
+}
+
+variable "cluster_encryption_config_resources" {
+  type        = list(any)
+  default     = ["secrets"]
+  description = "Cluster Encryption Config Resources to encrypt, e.g. ['secrets']"
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,4 +1,272 @@
-variable "example" {
+## eks_iam
+
+variable "iam_role_enabled" {
+  type        = bool
+  description = "Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module."
+  default     = false
+}
+
+## eks_iam_policy
+
+variable "iam_source_json_url" {
   type        = string
-  description = "The value which will be passed to the example module"
+  description = "IAM source json policy to download. This will be used as the `source_json` meaning the `var.iam_policy_statements` and `var.iam_policy_statements_template_path` can override it."
+  default     = null
+}
+
+variable "iam_policy_statements" {
+  type        = any
+  description = "IAM policy for the service account. Required if `var.iam_role_enabled` is `true`. This will not do variable replacements. Please see `var.iam_policy_statements_template_path`."
+  default     = {}
+}
+
+## eks_iam_role
+
+variable "aws_account_number" {
+  type        = string
+  description = "AWS account number of EKS cluster owner"
+  default     = null
+}
+
+variable "aws_partition" {
+  type        = string
+  description = "AWS partition: `aws`, `aws-cn`, or `aws-us-gov`. Applicable when `var.iam_role_enabled` is `true`."
+  default     = "aws"
+}
+
+variable "eks_cluster_oidc_issuer_url" {
+  type        = string
+  description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"
+  default     = null
+}
+
+variable "service_account_name" {
+  type        = string
+  description = "Kubernetes ServiceAccount name. Required if `var.iam_role_enabled` is `true`."
+  default     = null
+}
+
+variable "service_account_namespace" {
+  type        = string
+  description = "Kubernetes Namespace where service account is deployed. Required if `var.iam_role_enabled` is `true`."
+  default     = null
+}
+
+### helm_release
+
+variable "chart" {
+  type        = string
+  description = "Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended."
+}
+
+variable "description" {
+  type        = string
+  description = "Release description attribute (visible in the history)."
+  default     = null
+}
+
+variable "devel" {
+  type        = bool
+  description = "Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored."
+  default     = null
+}
+
+variable "repository" {
+  type        = string
+  description = "Repository URL where to locate the requested chart."
+  default     = null
+}
+
+variable "repository_ca_file" {
+  type        = string
+  description = "The Repositories CA file."
+  default     = null
+}
+
+variable "repository_cert_file" {
+  type        = string
+  description = "The repositories cert file."
+  default     = null
+}
+
+variable "repository_key_file" {
+  type        = string
+  description = "The repositories cert key file."
+  default     = null
+}
+
+variable "repository_password" {
+  type        = string
+  description = "Password for HTTP basic authentication against the repository."
+  default     = null
+}
+
+variable "repository_username" {
+  type        = string
+  description = "Username for HTTP basic authentication against the repository."
+  default     = null
+}
+
+variable "chart_version" {
+  type        = string
+  description = "Specify the exact chart version to install. If this is not specified, the latest version is installed."
+  default     = null
+}
+
+variable "create_namespace" {
+  type        = bool
+  description = "Create the namespace if it does not yet exist. Defaults to `false`."
+  default     = null
+}
+
+variable "kubernetes_namespace" {
+  type        = string
+  description = "The namespace to install the release into. Defaults to `default`."
+  default     = null
+}
+
+variable "atomic" {
+  type        = bool
+  description = "If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`."
+  default     = null
+}
+
+variable "cleanup_on_fail" {
+  type        = bool
+  description = "Allow deletion of new resources created in this upgrade when upgrade fails. Defaults to `false`."
+  default     = null
+}
+
+variable "dependency_update" {
+  type        = bool
+  description = "Runs helm dependency update before installing the chart. Defaults to `false`."
+  default     = null
+}
+
+variable "disable_openapi_validation" {
+  type        = bool
+  description = "If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`."
+  default     = null
+}
+
+variable "disable_webhooks" {
+  type        = bool
+  description = "Prevent hooks from running. Defaults to `false`."
+  default     = null
+}
+
+variable "force_update" {
+  type        = bool
+  description = "Force resource update through delete/recreate if needed. Defaults to `false`."
+  default     = null
+}
+
+variable "keyring" {
+  type        = string
+  description = "Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`."
+  default     = null
+}
+
+variable "lint" {
+  type        = bool
+  description = "Run the helm chart linter during the plan. Defaults to `false`."
+  default     = null
+}
+
+variable "max_history" {
+  type        = number
+  description = "Maximum number of release versions stored per release. Defaults to `0` (no limit)."
+  default     = null
+}
+
+variable "recreate_pods" {
+  type        = bool
+  description = "Perform pods restart during upgrade/rollback. Defaults to `false`."
+  default     = null
+}
+
+variable "render_subchart_notes" {
+  type        = bool
+  description = "If set, render subchart notes along with the parent. Defaults to `true`."
+  default     = null
+}
+
+variable "replace" {
+  type        = bool
+  description = "Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`."
+  default     = null
+}
+
+variable "reset_values" {
+  type        = bool
+  description = "When upgrading, reset the values to the ones built into the chart. Defaults to `false`."
+  default     = null
+}
+
+variable "reuse_values" {
+  type        = bool
+  description = "When upgrading, reuse the last release's values and merge in any overrides. If `reset_values` is specified, this is ignored. Defaults to `false`."
+  default     = null
+}
+
+variable "skip_crds" {
+  type        = bool
+  description = "If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`."
+  default     = null
+}
+
+variable "timeout" {
+  type        = number
+  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds."
+  default     = null
+}
+
+variable "values" {
+  type        = any
+  description = "List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options."
+  default     = null
+}
+
+variable "verify" {
+  type        = bool
+  description = "Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false`."
+  default     = null
+}
+
+variable "wait" {
+  type        = bool
+  description = "Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`."
+  default     = null
+}
+
+variable "wait_for_jobs" {
+  type        = bool
+  description = "If wait is enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as `timeout`. Defaults to `false`."
+  default     = null
+}
+
+variable "set" {
+  type = list(object({
+    name  = string
+    value = string
+    type  = string
+  }))
+  description = "Value block with custom values to be merged with the values yaml."
+  default     = []
+}
+
+variable "set_sensitive" {
+  type = list(object({
+    name  = string
+    value = string
+    type  = string
+  }))
+  description = "Value block with custom sensitive values to be merged with the values yaml that won't be exposed in the plan's diff."
+  default     = []
+}
+
+variable "postrender_binary_path" {
+  type        = string
+  description = "Relative or full path to command binary."
+  default     = null
 }

--- a/main.tf
+++ b/main.tf
@@ -36,10 +36,10 @@ resource "helm_release" "this" {
 
   name = module.this.name
 
-  chart         = var.chart
-  description   = var.description
-  devel         = var.devel
-  version       = var.chart_version
+  chart       = var.chart
+  description = var.description
+  devel       = var.devel
+  version     = var.chart_version
 
   repository           = var.repository
   repository_ca_file   = var.repository_ca_file

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,83 @@
-resource "random_integer" "example" {
-  count = module.this.enabled ? 1 : 0
-
-  min = 1
-  max = 50000
-  keepers = {
-    example = var.example
-  }
+locals {
+  enabled          = module.this.enabled
+  iam_role_enabled = local.enabled && var.iam_role_enabled
 }
 
-locals {
-  example = format("%v %v", var.example, join("", random_integer.example[*].result))
+module "eks_iam_policy" {
+  source = "git::https://github.com/cloudposse/terraform-aws-iam-policy.git"
+  # source  = "cloudposse/iam-policy/aws"
+  # version = "0.8.0"
+
+  enabled = local.iam_role_enabled
+
+  iam_source_json_url   = var.iam_source_json_url
+  iam_policy_statements = var.iam_policy_statements
+
+  context = module.this.context
+}
+
+module "eks_iam_role" {
+  source  = "cloudposse/eks-iam-role/aws"
+  version = "0.8.0"
+
+  enabled = local.iam_role_enabled
+
+  aws_account_number          = var.aws_account_number
+  aws_partition               = var.aws_partition
+  aws_iam_policy_document     = local.iam_role_enabled ? module.eks_iam_policy.json : "{}"
+  eks_cluster_oidc_issuer_url = var.eks_cluster_oidc_issuer_url
+  service_account_name        = var.service_account_name
+  service_account_namespace   = var.service_account_namespace
+
+  context = module.this.context
+}
+
+module "helm_release" {
+  source = "git::https://github.com/cloudposse/terraform-helm-release.git"
+
+  name          = module.this.name
+  description   = var.description
+  chart         = var.chart
+  devel         = var.devel
+  chart_version = var.chart_version
+
+  repository           = var.repository
+  repository_key_file  = var.repository_key_file
+  repository_cert_file = var.repository_cert_file
+  repository_ca_file   = var.repository_ca_file
+  repository_username  = var.repository_username
+  repository_password  = var.repository_password
+
+  # Note: creating a namespace here will not allow creation of labels/annotations
+  # For that, a `kubernetes_namespace` resource would have to be created.
+  # See https://github.com/hashicorp/terraform-provider-helm/issues/584#issuecomment-689555268
+  create_namespace = var.create_namespace
+  namespace        = var.kubernetes_namespace
+
+  values = var.values
+
+  atomic                     = var.atomic
+  cleanup_on_fail            = var.cleanup_on_fail
+  dependency_update          = var.dependency_update
+  disable_openapi_validation = var.disable_openapi_validation
+  disable_webhooks           = var.disable_webhooks
+  force_update               = var.force_update
+  keyring                    = var.keyring
+  lint                       = var.lint
+  max_history                = var.max_history
+  recreate_pods              = var.recreate_pods
+  render_subchart_notes      = var.render_subchart_notes
+  replace                    = var.replace
+  reset_values               = var.reset_values
+  reuse_values               = var.reuse_values
+  skip_crds                  = var.skip_crds
+  timeout                    = var.timeout
+  verify                     = var.verify
+  wait                       = var.wait
+  wait_for_jobs              = var.wait_for_jobs
+  set                        = var.set
+  set_sensitive              = var.set_sensitive
+  postrender_binary_path     = var.postrender_binary_path
+
+  context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -4,9 +4,8 @@ locals {
 }
 
 module "eks_iam_policy" {
-  source = "git::https://github.com/cloudposse/terraform-aws-iam-policy.git"
-  # source  = "cloudposse/iam-policy/aws"
-  # version = "0.8.0"
+  source  = "cloudposse/iam-policy/aws"
+  version = "0.1.0"
 
   enabled = local.iam_role_enabled
 
@@ -33,7 +32,8 @@ module "eks_iam_role" {
 }
 
 module "helm_release" {
-  source = "git::https://github.com/cloudposse/terraform-helm-release.git"
+  source  = "cloudposse/release/helm"
+  version = "0.1.0"
 
   name          = module.this.name
   description   = var.description

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,4 @@
-output "id" {
-  description = "ID of the created example"
-  value       = module.this.enabled ? module.this.id : null
-}
-
-output "example" {
-  description = "Example output"
-  value       = module.this.enabled ? local.example : null
-}
-
-output "random" {
-  description = "Stable random number for this example"
-  value       = module.this.enabled ? join("", random_integer.example[*].result) : null
+output "metadata" {
+  description = "Block status of the deployed release."
+  value       = try(module.helm_release.this[0].metadata, null)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,48 @@
+## eks_iam_role
+
+output "service_account_namespace" {
+  value       = module.eks_iam_policy.service_account_namespace
+  description = "Kubernetes Service Account namespace"
+}
+
+output "service_account_name" {
+  value       = module.eks_iam_policy.service_account_name
+  description = "Kubernetes Service Account name"
+}
+
+output "service_account_role_name" {
+  value       = module.eks_iam_policy.service_account_role_name
+  description = "IAM role name"
+}
+
+output "service_account_role_unique_id" {
+  value       = module.eks_iam_policy.service_account_role_unique_id
+  description = "IAM role unique ID"
+}
+
+output "service_account_role_arn" {
+  value       = module.eks_iam_policy.service_account_role_arn
+  description = "IAM role ARN"
+}
+
+output "service_account_policy_name" {
+  value       = module.eks_iam_policy.service_account_policy_name
+  description = "IAM policy name"
+}
+
+output "service_account_policy_id" {
+  value       = module.eks_iam_policy.service_account_policy_id
+  description = "IAM policy ID"
+}
+
+output "service_account_policy_arn" {
+  value       = module.eks_iam_policy.service_account_policy_arn
+  description = "IAM policy ARN"
+}
+
+## helm_release
+
 output "metadata" {
   description = "Block status of the deployed release."
-  value       = try(module.helm_release.this[0].metadata, null)
+  value       = local.enabled ? helm_release.this[0].metadata : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,42 +1,42 @@
 ## eks_iam_role
 
 output "service_account_namespace" {
-  value       = module.eks_iam_policy.service_account_namespace
+  value       = module.eks_iam_role.service_account_namespace
   description = "Kubernetes Service Account namespace"
 }
 
 output "service_account_name" {
-  value       = module.eks_iam_policy.service_account_name
+  value       = module.eks_iam_role.service_account_name
   description = "Kubernetes Service Account name"
 }
 
 output "service_account_role_name" {
-  value       = module.eks_iam_policy.service_account_role_name
+  value       = module.eks_iam_role.service_account_role_name
   description = "IAM role name"
 }
 
 output "service_account_role_unique_id" {
-  value       = module.eks_iam_policy.service_account_role_unique_id
+  value       = module.eks_iam_role.service_account_role_unique_id
   description = "IAM role unique ID"
 }
 
 output "service_account_role_arn" {
-  value       = module.eks_iam_policy.service_account_role_arn
+  value       = module.eks_iam_role.service_account_role_arn
   description = "IAM role ARN"
 }
 
 output "service_account_policy_name" {
-  value       = module.eks_iam_policy.service_account_policy_name
+  value       = module.eks_iam_role.service_account_policy_name
   description = "IAM policy name"
 }
 
 output "service_account_policy_id" {
-  value       = module.eks_iam_policy.service_account_policy_id
+  value       = module.eks_iam_role.service_account_policy_id
   description = "IAM policy ID"
 }
 
 output "service_account_policy_arn" {
-  value       = module.eks_iam_policy.service_account_policy_arn
+  value       = module.eks_iam_role.service_account_policy_arn
   description = "IAM policy ARN"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "aws_partition" {
 variable "eks_cluster_oidc_issuer_url" {
   type        = string
   description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"
-  default     = null
+  default     = ""
 }
 
 variable "service_account_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "iam_policy_statements" {
 
 variable "aws_account_number" {
   type        = string
-  description = "AWS account number of EKS cluster owner"
+  description = "AWS account number of EKS cluster owner."
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,266 @@
-variable "example" {
-  description = "Example variable"
-  default     = "hello world"
+variable "iam_role_enabled" {
+  type        = bool
+  description = "Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module."
+  default     = false
+}
+
+variable "iam_source_json_url" {
+  type        = string
+  description = "IAM source json policy to download. This will be used as the `source_json` meaning the `var.iam_policy_statements` and `var.iam_policy_statements_template_path` can override it."
+  default     = null
+}
+
+variable "iam_policy_statements" {
+  type        = any
+  description = "IAM policy for the service account. Required if `var.iam_role_enabled` is `true`. This will not do variable replacements. Please see `var.iam_policy_statements_template_path`."
+  default     = {}
+}
+
+variable "aws_account_number" {
+  type        = string
+  description = "AWS account number of EKS cluster owner"
+  default     = null
+}
+
+variable "aws_partition" {
+  type        = string
+  description = "AWS partition: `aws`, `aws-cn`, or `aws-us-gov`. Applicable when `var.iam_role_enabled` is `true`."
+  default     = "aws"
+}
+
+variable "service_account_name" {
+  type        = string
+  description = "Kubernetes ServiceAccount name. Required if `var.iam_role_enabled` is `true`."
+  default     = null
+}
+
+variable "eks_cluster_oidc_issuer_url" {
+  type        = string
+  description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"
+  default     = null
+}
+
+variable "service_account_namespace" {
+  type        = string
+  description = "Kubernetes Namespace where service account is deployed. Required if `var.iam_role_enabled` is `true`."
+  default     = null
+}
+
+### helm_release
+
+variable "description" {
+  type        = string
+  description = "Set release description attribute (visible in the history)."
+  default     = null
+}
+
+variable "chart" {
+  type        = string
+  description = "Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended."
+}
+
+variable "repository" {
+  type        = string
+  description = "Repository URL where to locate the requested chart."
+  default     = null
+}
+
+variable "repository_key_file" {
+  type        = string
+  description = "The repositories cert key file"
+  default     = null
+}
+
+variable "repository_cert_file" {
+  type        = string
+  description = "The repositories cert file"
+  default     = null
+}
+
+variable "repository_ca_file" {
+  type        = string
+  description = "The Repositories CA File."
+  default     = null
+}
+
+variable "repository_username" {
+  type        = string
+  description = "Username for HTTP basic authentication against the repository."
+  default     = null
+}
+
+variable "repository_password" {
+  type        = string
+  description = "Password for HTTP basic authentication against the repository."
+  default     = null
+}
+
+variable "devel" {
+  type        = bool
+  description = "Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored."
+  default     = null
+}
+
+variable "chart_version" {
+  type        = string
+  description = "Specify the exact chart version to install. If this is not specified, the latest version is installed."
+  default     = null
+}
+
+variable "kubernetes_namespace" {
+  type        = string
+  description = "The namespace to install the release into. Defaults to `default`."
+  default     = null
+}
+
+variable "verify" {
+  type        = bool
+  description = "Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false`."
+  default     = null
+}
+
+variable "keyring" {
+  type        = string
+  description = "Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`"
+  default     = null
+}
+
+variable "timeout" {
+  type        = number
+  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds"
+  default     = null
+}
+
+variable "disable_webhooks" {
+  type        = bool
+  description = "Prevent hooks from running. Defaults to `false`."
+  default     = null
+}
+
+variable "reuse_values" {
+  type        = bool
+  description = "When upgrading, reuse the last release's values and merge in any overrides. If `reset_values` is specified, this is ignored. Defaults to `false`."
+  default     = null
+}
+
+variable "reset_values" {
+  type        = bool
+  description = "When upgrading, reset the values to the ones built into the chart. Defaults to `false`."
+  default     = null
+}
+
+variable "force_update" {
+  type        = bool
+  description = "Force resource update through delete/recreate if needed. Defaults to `false`."
+  default     = null
+}
+
+variable "recreate_pods" {
+  type        = bool
+  description = " Perform pods restart during upgrade/rollback. Defaults to `false`."
+  default     = null
+}
+
+variable "cleanup_on_fail" {
+  type        = bool
+  description = "Allow deletion of new resources created in this upgrade when upgrade fails. Defaults to `false`."
+  default     = null
+}
+
+variable "max_history" {
+  type        = number
+  description = "Maximum number of release versions stored per release. Defaults to `0` (no limit)."
+  default     = null
+}
+
+variable "atomic" {
+  type        = bool
+  description = "If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`."
+  default     = null
+}
+
+variable "skip_crds" {
+  type        = bool
+  description = "If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`."
+  default     = null
+}
+
+variable "render_subchart_notes" {
+  type        = bool
+  description = "If set, render subchart notes along with the parent. Defaults to `true`."
+  default     = null
+}
+
+variable "disable_openapi_validation" {
+  type        = bool
+  description = "If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`."
+  default     = null
+}
+
+variable "wait" {
+  type        = bool
+  description = "Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`."
+  default     = null
+}
+
+variable "wait_for_jobs" {
+  type        = bool
+  description = "If wait is enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as `timeout`. Defaults to `false`."
+  default     = null
+}
+
+variable "values" {
+  type        = any
+  description = "List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options."
+  default     = null
+}
+
+variable "set" {
+  type = list(object({
+    name  = string
+    value = string
+    type  = string
+  }))
+  description = "Value block with custom values to be merged with the values yaml."
+  default     = []
+}
+
+variable "set_sensitive" {
+  type = list(object({
+    name  = string
+    value = string
+    type  = string
+  }))
+  description = "Value block with custom sensitive values to be merged with the values yaml that won't be exposed in the plan's diff."
+  default     = []
+}
+
+variable "dependency_update" {
+  type        = bool
+  description = "Runs helm dependency update before installing the chart. Defaults to `false`."
+  default     = null
+}
+
+variable "replace" {
+  type        = bool
+  description = "Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`."
+  default     = null
+}
+
+variable "lint" {
+  type        = bool
+  description = "Run the helm chart linter during the plan. Defaults to `false`."
+  default     = null
+}
+
+variable "create_namespace" {
+  type        = bool
+  description = "Create the namespace if it does not yet exist. Defaults to `false`."
+  default     = null
+}
+
+variable "postrender_binary_path" {
+  type        = string
+  description = "Relative or full path to command binary."
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,12 @@
+## eks_iam
+
 variable "iam_role_enabled" {
   type        = bool
   description = "Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module."
   default     = false
 }
+
+## eks_iam_policy
 
 variable "iam_source_json_url" {
   type        = string
@@ -16,6 +20,8 @@ variable "iam_policy_statements" {
   default     = {}
 }
 
+## eks_iam_role
+
 variable "aws_account_number" {
   type        = string
   description = "AWS account number of EKS cluster owner"
@@ -28,15 +34,15 @@ variable "aws_partition" {
   default     = "aws"
 }
 
-variable "service_account_name" {
-  type        = string
-  description = "Kubernetes ServiceAccount name. Required if `var.iam_role_enabled` is `true`."
-  default     = null
-}
-
 variable "eks_cluster_oidc_issuer_url" {
   type        = string
   description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"
+  default     = null
+}
+
+variable "service_account_name" {
+  type        = string
+  description = "Kubernetes ServiceAccount name. Required if `var.iam_role_enabled` is `true`."
   default     = null
 }
 
@@ -48,50 +54,14 @@ variable "service_account_namespace" {
 
 ### helm_release
 
-variable "description" {
-  type        = string
-  description = "Release description attribute (visible in the history)."
-  default     = null
-}
-
 variable "chart" {
   type        = string
   description = "Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended."
 }
 
-variable "repository" {
+variable "description" {
   type        = string
-  description = "Repository URL where to locate the requested chart."
-  default     = null
-}
-
-variable "repository_key_file" {
-  type        = string
-  description = "The repositories cert key file."
-  default     = null
-}
-
-variable "repository_cert_file" {
-  type        = string
-  description = "The repositories cert file."
-  default     = null
-}
-
-variable "repository_ca_file" {
-  type        = string
-  description = "The Repositories CA file."
-  default     = null
-}
-
-variable "repository_username" {
-  type        = string
-  description = "Username for HTTP basic authentication against the repository."
-  default     = null
-}
-
-variable "repository_password" {
-  type        = string
-  description = "Password for HTTP basic authentication against the repository."
+  description = "Release description attribute (visible in the history)."
   default     = null
 }
 
@@ -101,9 +71,51 @@ variable "devel" {
   default     = null
 }
 
+variable "repository" {
+  type        = string
+  description = "Repository URL where to locate the requested chart."
+  default     = null
+}
+
+variable "repository_ca_file" {
+  type        = string
+  description = "The Repositories CA file."
+  default     = null
+}
+
+variable "repository_cert_file" {
+  type        = string
+  description = "The repositories cert file."
+  default     = null
+}
+
+variable "repository_key_file" {
+  type        = string
+  description = "The repositories cert key file."
+  default     = null
+}
+
+variable "repository_password" {
+  type        = string
+  description = "Password for HTTP basic authentication against the repository."
+  default     = null
+}
+
+variable "repository_username" {
+  type        = string
+  description = "Username for HTTP basic authentication against the repository."
+  default     = null
+}
+
 variable "chart_version" {
   type        = string
   description = "Specify the exact chart version to install. If this is not specified, the latest version is installed."
+  default     = null
+}
+
+variable "create_namespace" {
+  type        = bool
+  description = "Create the namespace if it does not yet exist. Defaults to `false`."
   default     = null
 }
 
@@ -113,51 +125,9 @@ variable "kubernetes_namespace" {
   default     = null
 }
 
-variable "verify" {
+variable "atomic" {
   type        = bool
-  description = "Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false`."
-  default     = null
-}
-
-variable "keyring" {
-  type        = string
-  description = "Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`."
-  default     = null
-}
-
-variable "timeout" {
-  type        = number
-  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds."
-  default     = null
-}
-
-variable "disable_webhooks" {
-  type        = bool
-  description = "Prevent hooks from running. Defaults to `false`."
-  default     = null
-}
-
-variable "reuse_values" {
-  type        = bool
-  description = "When upgrading, reuse the last release's values and merge in any overrides. If `reset_values` is specified, this is ignored. Defaults to `false`."
-  default     = null
-}
-
-variable "reset_values" {
-  type        = bool
-  description = "When upgrading, reset the values to the ones built into the chart. Defaults to `false`."
-  default     = null
-}
-
-variable "force_update" {
-  type        = bool
-  description = "Force resource update through delete/recreate if needed. Defaults to `false`."
-  default     = null
-}
-
-variable "recreate_pods" {
-  type        = bool
-  description = "Perform pods restart during upgrade/rollback. Defaults to `false`."
+  description = "If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`."
   default     = null
 }
 
@@ -167,21 +137,51 @@ variable "cleanup_on_fail" {
   default     = null
 }
 
+variable "dependency_update" {
+  type        = bool
+  description = "Runs helm dependency update before installing the chart. Defaults to `false`."
+  default     = null
+}
+
+variable "disable_openapi_validation" {
+  type        = bool
+  description = "If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`."
+  default     = null
+}
+
+variable "disable_webhooks" {
+  type        = bool
+  description = "Prevent hooks from running. Defaults to `false`."
+  default     = null
+}
+
+variable "force_update" {
+  type        = bool
+  description = "Force resource update through delete/recreate if needed. Defaults to `false`."
+  default     = null
+}
+
+variable "keyring" {
+  type        = string
+  description = "Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`."
+  default     = null
+}
+
+variable "lint" {
+  type        = bool
+  description = "Run the helm chart linter during the plan. Defaults to `false`."
+  default     = null
+}
+
 variable "max_history" {
   type        = number
   description = "Maximum number of release versions stored per release. Defaults to `0` (no limit)."
   default     = null
 }
 
-variable "atomic" {
+variable "recreate_pods" {
   type        = bool
-  description = "If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`."
-  default     = null
-}
-
-variable "skip_crds" {
-  type        = bool
-  description = "If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`."
+  description = "Perform pods restart during upgrade/rollback. Defaults to `false`."
   default     = null
 }
 
@@ -191,9 +191,45 @@ variable "render_subchart_notes" {
   default     = null
 }
 
-variable "disable_openapi_validation" {
+variable "replace" {
   type        = bool
-  description = "If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`."
+  description = "Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`."
+  default     = null
+}
+
+variable "reset_values" {
+  type        = bool
+  description = "When upgrading, reset the values to the ones built into the chart. Defaults to `false`."
+  default     = null
+}
+
+variable "reuse_values" {
+  type        = bool
+  description = "When upgrading, reuse the last release's values and merge in any overrides. If `reset_values` is specified, this is ignored. Defaults to `false`."
+  default     = null
+}
+
+variable "skip_crds" {
+  type        = bool
+  description = "If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`."
+  default     = null
+}
+
+variable "timeout" {
+  type        = number
+  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds."
+  default     = null
+}
+
+variable "values" {
+  type        = any
+  description = "List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options."
+  default     = null
+}
+
+variable "verify" {
+  type        = bool
+  description = "Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false`."
   default     = null
 }
 
@@ -206,12 +242,6 @@ variable "wait" {
 variable "wait_for_jobs" {
   type        = bool
   description = "If wait is enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as `timeout`. Defaults to `false`."
-  default     = null
-}
-
-variable "values" {
-  type        = any
-  description = "List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options."
   default     = null
 }
 
@@ -233,30 +263,6 @@ variable "set_sensitive" {
   }))
   description = "Value block with custom sensitive values to be merged with the values yaml that won't be exposed in the plan's diff."
   default     = []
-}
-
-variable "dependency_update" {
-  type        = bool
-  description = "Runs helm dependency update before installing the chart. Defaults to `false`."
-  default     = null
-}
-
-variable "replace" {
-  type        = bool
-  description = "Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`."
-  default     = null
-}
-
-variable "lint" {
-  type        = bool
-  description = "Run the helm chart linter during the plan. Defaults to `false`."
-  default     = null
-}
-
-variable "create_namespace" {
-  type        = bool
-  description = "Create the namespace if it does not yet exist. Defaults to `false`."
-  default     = null
 }
 
 variable "postrender_binary_path" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "service_account_namespace" {
 
 variable "description" {
   type        = string
-  description = "Set release description attribute (visible in the history)."
+  description = "Release description attribute (visible in the history)."
   default     = null
 }
 
@@ -67,19 +67,19 @@ variable "repository" {
 
 variable "repository_key_file" {
   type        = string
-  description = "The repositories cert key file"
+  description = "The repositories cert key file."
   default     = null
 }
 
 variable "repository_cert_file" {
   type        = string
-  description = "The repositories cert file"
+  description = "The repositories cert file."
   default     = null
 }
 
 variable "repository_ca_file" {
   type        = string
-  description = "The Repositories CA File."
+  description = "The Repositories CA file."
   default     = null
 }
 
@@ -121,13 +121,13 @@ variable "verify" {
 
 variable "keyring" {
   type        = string
-  description = "Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`"
+  description = "Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`."
   default     = null
 }
 
 variable "timeout" {
   type        = number
-  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds"
+  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds."
   default     = null
 }
 
@@ -157,7 +157,7 @@ variable "force_update" {
 
 variable "recreate_pods" {
   type        = bool
-  description = " Perform pods restart during upgrade/rollback. Defaults to `false`."
+  description = "Perform pods restart during upgrade/rollback. Defaults to `false`."
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "aws_partition" {
 
 variable "eks_cluster_oidc_issuer_url" {
   type        = string
-  description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"
+  description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)."
   default     = ""
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,15 +1,3 @@
 terraform {
   required_version = ">= 0.13"
-
-  required_providers {
-    # Update these to reflect the actual requirements of your module
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.2"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.2"
-    }
-  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,11 @@
 terraform {
   required_version = ">= 0.13"
+
+  required_providers {
+    # Update these to reflect the actual requirements of your module
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.2"
+    }
+  }
 }


### PR DESCRIPTION
## Depends on https://github.com/cloudposse/terraform-aws-iam-policy/pull/1

## what
* [x] Initial `helm_release` wrapper
* [x] Move https://github.com/cloudposse/terraform-helm-release/pull/1 to this repo
* [x] add https://github.com/cloudposse/terraform-aws-eks-iam-role
* [x] add iam policy from https://github.com/cloudposse/terraform-aws-iam-policy
    * or should the iam policy module reference be put directly in the `terraform-aws-eks-iam-role` module ?

## why
* Make it easier to compose helm releases with iam roles (and potentially other related resources)

## references
* https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release

