### PR TITLE
Feat: allow `var.name` to be set to empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ module "helm_release" {
 }
 ```
 
-This will result in an IAM role with a name such as: `eg-uw2-dev-echo@kube-system` instead of `eg-uw2-dev-echo-echo@kube-system`.
+This will result in an IAM role with a name such as: `eg-uw2-dev-echo@echo` instead of `eg-uw2-dev-echo-echo@echo`.
 Additionally, if `var.name` is empty, the name used for the Helm Release will be that of `var.chart`.
 
 
@@ -465,14 +465,16 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
-|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] | [![Yonathan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonathan Koren][korenyoni_homepage] |
+|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [nitrocode_homepage]: https://github.com/nitrocode
   [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
+  [korenyoni_homepage]: https://github.com/korenyoni
+  [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -118,6 +118,31 @@ usage: |-
   }
   ```
 
+  If `var.service_account_name` is set, then `var.name` can be set to "" in order to achieve a shorter name for the IAM
+  Role created for the ServiceAccount:
+
+  ```hcl
+  module "helm_release" {
+    source  = "cloudposse/helm-release/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
+
+    name = ""
+
+    create_namespace     = true
+    kubernetes_namespace = "echo"
+
+    service_account_name      = "echo"
+    service_account_namespace = "echo"
+
+    iam_role_enabled = true
+    ...
+  }
+  ```
+
+  This will result in an IAM role with a name such as: `eg-uw2-dev-echo@kube-system` instead of `eg-uw2-dev-echo-echo@kube-system`.
+  Additionally, if `var.name` is empty, the name used for the Helm Release will be that of `var.chart`.
+
 # Example usage
 examples: |-
   Here is an example of using this module:

--- a/README.yaml
+++ b/README.yaml
@@ -140,7 +140,7 @@ usage: |-
   }
   ```
 
-  This will result in an IAM role with a name such as: `eg-uw2-dev-echo@kube-system` instead of `eg-uw2-dev-echo-echo@kube-system`.
+  This will result in an IAM role with a name such as: `eg-uw2-dev-echo@echo` instead of `eg-uw2-dev-echo-echo@echo`.
   Additionally, if `var.name` is empty, the name used for the Helm Release will be that of `var.chart`.
 
 # Example usage
@@ -163,3 +163,5 @@ contributors:
     github: "osterman"
   - name: "RB"
     github: "nitrocode"
+  - name: "Yonathan Koren"
+    github: "korenyoni"

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,9 @@ module "eks_iam_role" {
 resource "helm_release" "this" {
   count = local.enabled ? 1 : 0
 
-  name = module.this.name
+  # Allows var.name to be empty, which is allowed to be the case for this module since var.name is optional in eks-iam-role.
+  # For more information, see: https://github.com/cloudposse/terraform-aws-eks-iam-role
+  name = coalesce(module.this.name, var.chart)
 
   chart       = var.chart
   description = var.description


### PR DESCRIPTION
## what
* Allow `var.name` to be set to empty by coalescing `var.name` with `var.chart` for the `helm_release` resource.
* Update README.

## why
* `var.name` [is optional in eks-iam-role](https://github.com/cloudposse/terraform-aws-eks-iam-role/blob/5022028bfd192101929a9df64adf849101a81ab7/main.tf#L8-L25). Omitting it results in shorter names for IAM Roles created for ServiceAccounts, if `var.service_account_name` is supplied. However, the `name` attribute for the `helm_release` resource is not optional, so it should be coalesced with `var.chart`.

## references
* https://github.com/cloudposse/terraform-aws-eks-iam-role/blob/5022028bfd192101929a9df64adf849101a81ab7/main.tf#L8-L25

