### PR TITLE
Bump eks iam to 0.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | cloudposse/iam-policy/aws | 0.3.0 |
-| <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.11.0 |
+| <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.11.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -412,7 +412,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,7 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eks_iam_policy"></a> [eks\_iam\_policy](#module\_eks\_iam\_policy) | cloudposse/iam-policy/aws | 0.3.0 |
-| <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.11.0 |
+| <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 0.11.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "eks_iam_policy" {
 
 module "eks_iam_role" {
   source  = "cloudposse/eks-iam-role/aws"
-  version = "0.11.0"
+  version = "0.11.1"
 
   enabled = local.iam_role_enabled
 


### PR DESCRIPTION
## what
* Bump eks iam to 0.11.1

## why
* Prevent iam role creation without eks oidc set

## references
* Depends on https://github.com/cloudposse/terraform-aws-eks-iam-role/pull/24
* Closes PR https://github.com/cloudposse/terraform-aws-helm-release/pull/24

