### PR TITLE
Override the Release name

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Available targets:
 | <a name="input_postrender_binary_path"></a> [postrender\_binary\_path](#input\_postrender\_binary\_path) | Relative or full path to command binary. | `string` | `null` | no |
 | <a name="input_recreate_pods"></a> [recreate\_pods](#input\_recreate\_pods) | Perform pods restart during upgrade/rollback. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_release_name"></a> [release\_name](#input\_release\_name) | The name of the release to be installed. If omitted, use the name input, and if that's omitted, use the chart input. | `string` | `""` | no |
 | <a name="input_render_subchart_notes"></a> [render\_subchart\_notes](#input\_render\_subchart\_notes) | If set, render subchart notes along with the parent. Defaults to `true`. | `bool` | `null` | no |
 | <a name="input_replace"></a> [replace](#input\_replace) | Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | Repository URL where to locate the requested chart. | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -69,6 +69,7 @@
 | <a name="input_postrender_binary_path"></a> [postrender\_binary\_path](#input\_postrender\_binary\_path) | Relative or full path to command binary. | `string` | `null` | no |
 | <a name="input_recreate_pods"></a> [recreate\_pods](#input\_recreate\_pods) | Perform pods restart during upgrade/rollback. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_release_name"></a> [release\_name](#input\_release\_name) | The name of the release to be installed. If omitted, use the name input, and if that's omitted, use the chart input. | `string` | `""` | no |
 | <a name="input_render_subchart_notes"></a> [render\_subchart\_notes](#input\_render\_subchart\_notes) | If set, render subchart notes along with the parent. Defaults to `true`. | `bool` | `null` | no |
 | <a name="input_replace"></a> [replace](#input\_replace) | Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | Repository URL where to locate the requested chart. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "helm_release" "this" {
 
   # Allows var.name to be empty, which is allowed to be the case for this module since var.name is optional in eks-iam-role.
   # For more information, see: https://github.com/cloudposse/terraform-aws-eks-iam-role
-  name = coalesce(module.this.name, var.chart)
+  name = coalesce(var.release_name, module.this.name, var.chart)
 
   chart       = var.chart
   description = var.description

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,12 @@ variable "chart" {
   description = "Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended."
 }
 
+variable "release_name" {
+  type        = string
+  description = "The name of the release to be installed. If omitted, use the name input, and if that's omitted, use the chart input."
+  default     = ""
+}
+
 variable "description" {
   type        = string
   description = "Release description attribute (visible in the history)."


### PR DESCRIPTION
## what
* Override the release name

## why
* Deploy multiple of the same chart to the same namespace

## references
* Closes https://github.com/cloudposse/terraform-aws-helm-release/issues/22