### PR TITLE
Fix: Make `eks_cluster_oidc_issuer_url` Non-optional and Add Validation Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Available targets:
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
-| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted). | `string` | `""` | no |
+| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted). | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -47,7 +47,7 @@
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version `>0.0.0-0`. If version is set, this is ignored. | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false`. | `bool` | `null` | no |
-| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted). | `string` | `""` | no |
+| <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the EKS cluster (initial "https://" may be omitted). | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,11 @@ variable "aws_partition" {
 variable "eks_cluster_oidc_issuer_url" {
   type        = string
   description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)."
-  default     = ""
+
+  validation {
+    condition     = length(var.eks_cluster_oidc_issuer_url) > 0
+    error_message = "The eks_cluster_oidc_issuer_url value must have a value."
+  }
 }
 
 variable "service_account_role_arn_annotation_enabled" {
@@ -51,13 +55,13 @@ variable "service_account_role_arn_annotation_enabled" {
   description = <<-EOT
   Whether or not to dynamically insert an `eks.amazonaws.com/role-arn` annotation into `$var.service_account_set_key_path.annotations`
   (by default, `serviceAccount.annotations`), with the value being the ARN of the IAM role created when `var.iam_role_enabled`.
-  
+
   Assuming the Helm Chart follows the standard convention of rendering ServiceAccount annotations in `serviceAccount.annotations`
   (or a similar convention, which can be overriden by `var.service_account_set_key_path` as needed),
   this allows the ServiceAccount created by the Helm Chart to assume the IAM Role in question via the EKS OIDC IdP, without
   the consumer of this module having to set this annotation via `var.values` or `var.set`, which would involve manually
   rendering the IAM Role ARN beforehand.
-  
+
   Ignored if `var.iam_role_enabled` is `false`.
   EOT
   default     = true
@@ -67,7 +71,7 @@ variable "service_account_set_key_path" {
   type        = string
   description = <<-EOT
   The key path used by Helm Chart values for ServiceAccount-related settings (e.g. `serviceAccount...` or `rbac.serviceAccount...`).
-  
+
   Ignored if either `var.service_account_role_arn_annotation_enabled` or `var.iam_role_enabled` are set to `false`.
   EOT
   default     = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"


### PR DESCRIPTION
## what
* Make `eks_cluster_oidc_issuer_url` non-optional and add validation rule.

## why
* `eks_cluster_oidc_issuer_url` is currently optional, except it supplies the same value directly to `cloudposse/eks-iam-role/aws`, which has a validation rule on it not being empty. This results in a run-time error if `eks_cluster_oidc_issuer_url` is empty.

```hcl
╷
│ Error: Invalid value for variable
│ 
│   on .terraform/modules/ocean_controller/main.tf line 28, in module "eks_iam_role":
│   28:   eks_cluster_oidc_issuer_url = var.eks_cluster_oidc_issuer_url
│ 
│ The eks_cluster_oidc_issuer_url value must have a value.
│ 
│ This was checked by the validation rule at .terraform/modules/ocean_controller.eks_iam_role/variables.tf:38,3-13.
╵
Releasing state lock. This may take a few moments...
exit status 1
```

See: https://github.com/cloudposse/terraform-aws-eks-iam-role/blob/7fbf1965f71d6897ec583c30fac2875a6582a8d2/variables.tf#L34-L42

## references
* Closes #26 

