### PR TITLE
feat: Add iam_policy_enabled to allow IAM roles without policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Available targets:
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_iam_policy_enabled"></a> [iam\_policy\_enabled](#input\_iam\_policy\_enabled) | Whether to create and attach an IAM policy to the created IAM role | `bool` | `true` | no |
 | <a name="input_iam_policy_statements"></a> [iam\_policy\_statements](#input\_iam\_policy\_statements) | DEPRECATED, use `iam_source_policy_documents` instead: IAM policy (as `map(string)`)for the service account. | `any` | `{}` | no |
 | <a name="input_iam_role_enabled"></a> [iam\_role\_enabled](#input\_iam\_role\_enabled) | Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module. | `bool` | `false` | no |
 | <a name="input_iam_source_json_url"></a> [iam\_source\_json\_url](#input\_iam\_source\_json\_url) | IAM source json policy to download. The downloaded policy will be combined with `iam_source_policy_statements`. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -89,10 +89,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 
 This  module deploys a [Helm chart](https://helm.sh/docs/topics/charts/) with

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -55,6 +55,7 @@
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_iam_policy_enabled"></a> [iam\_policy\_enabled](#input\_iam\_policy\_enabled) | Whether to create and attach an IAM policy to the created IAM role | `bool` | `true` | no |
 | <a name="input_iam_policy_statements"></a> [iam\_policy\_statements](#input\_iam\_policy\_statements) | DEPRECATED, use `iam_source_policy_documents` instead: IAM policy (as `map(string)`)for the service account. | `any` | `{}` | no |
 | <a name="input_iam_role_enabled"></a> [iam\_role\_enabled](#input\_iam\_role\_enabled) | Whether to create an IAM role. Setting this to `true` will also replace any occurrences of `{service_account_role_arn}` in `var.values_template_path` with the ARN of the IAM role created by this module. | `bool` | `false` | no |
 | <a name="input_iam_source_json_url"></a> [iam\_source\_json\_url](#input\_iam\_source\_json\_url) | IAM source json policy to download. The downloaded policy will be combined with `iam_source_policy_statements`. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
-  enabled          = module.this.enabled
-  iam_role_enabled = local.enabled && var.iam_role_enabled
+  enabled            = module.this.enabled
+  iam_role_enabled   = local.enabled && var.iam_role_enabled
+  iam_policy_enabled = local.iam_role_enabled && var.iam_policy_enabled
 
   create_namespace         = local.enabled && coalesce(var.create_namespace_with_kubernetes, var.create_namespace, false)
   create_namespace_via_k8s = local.enabled && (var.create_namespace_with_kubernetes == true) # true && null yields error
@@ -14,7 +15,7 @@ module "eks_iam_policy" {
   source  = "cloudposse/iam-policy/aws"
   version = "1.0.1"
 
-  enabled = local.iam_role_enabled
+  enabled = local.iam_policy_enabled
 
   iam_source_policy_documents = var.iam_source_policy_documents
   iam_source_json_url         = var.iam_source_json_url
@@ -30,7 +31,7 @@ module "eks_iam_role" {
   enabled = local.iam_role_enabled
 
   aws_account_number          = var.aws_account_number
-  aws_iam_policy_document     = local.iam_role_enabled ? [module.eks_iam_policy.json] : ["{}"]
+  aws_iam_policy_document     = local.iam_policy_enabled ? [module.eks_iam_policy.json] : []
   aws_partition               = var.aws_partition
   eks_cluster_oidc_issuer_url = var.eks_cluster_oidc_issuer_url
   service_account_name        = var.service_account_name

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "iam_role_enabled" {
 
 ## eks_iam_policy
 
+variable "iam_policy_enabled" {
+  type        = bool
+  description = "Whether to create and attach an IAM policy to the created IAM role"
+  default     = true
+}
+
 variable "iam_source_policy_documents" {
   type        = list(string)
   description = "List of JSON IAM policy documents that are merged together into role's policy. Statements defined in `source_policy_documents` or `source_json` must have unique sids."


### PR DESCRIPTION
## what
- New variable `iam_policy_enabled` which allows creating iam eks role without a policy.
- Also changed `["{}"]` to `[]` in `module "eks_iam_role".aws_iam_policy_document` when `iam_policy_enabled` is true. as `"{}"` is still an item and the module was still attempting to create a policy. (because its based on `length(var. aws_iam_policy_document)`)

## why

- When utilizing resource-based-policies access is granted on that specific resource, role that is granted access can have no policies at all, which is often a desired case.
- [On this issue](https://github.com/cloudposse/terraform-aws-helm-release/issues/37) it was suggested that `deny *` policy can always be used when no policy is desired. But this does not work when using resource based policies, as the role is denied all access, including the on in resource's policy
- In my particular case I had a KMS key that allowed a role to decrypt using this key. The role needed no policies, so following the suggestion mention above I added deny all policy, which prevented by role from using the key. Removing the policy made things work, so this feature clearly has a valid use case.

## references
- Fixes https://github.com/cloudposse/terraform-aws-helm-release/issues/37
- From AWS IAM documentation: [Evaluating identity-based policies with resource-based policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)

>Identity-based policies and resource-based policies grant permissions to the identities or resources to which they are attached. When an IAM entity (user or role) requests access to a resource within the same account, AWS evaluates all the permissions granted by the identity-based and resource-based policies. The resulting permissions are the total permissions of the two types. If an action is allowed by an identity-based policy, a resource-based policy, or both, then AWS allows the action. An explicit deny in either of these policies overrides the allow.