### PR TITLE
Pin version of helm provider to 2.x as 3 is not currently compatible

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -16,24 +16,27 @@ kubernetes_version = "1.26"
 addons = [
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#vpc-cni-latest-available-version
   {
-    addon_name               = "vpc-cni"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "vpc-cni"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
   {
-    addon_name               = "kube-proxy"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "kube-proxy"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
   {
-    addon_name               = "coredns"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "coredns"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
 ]
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -12,7 +12,7 @@ name = "helm"
 
 availability_zones = ["us-east-2a", "us-east-2b"]
 
-kubernetes_version = "1.26"
+kubernetes_version = "1.29"
 addons = [
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#vpc-cni-latest-available-version
   {

--- a/examples/complete/main-eks.tf
+++ b/examples/complete/main-eks.tf
@@ -45,7 +45,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.3.0"
+  version = "2.4.2"
 
   availability_zones              = var.availability_zones
   vpc_id                          = module.vpc.vpc_id
@@ -64,7 +64,7 @@ module "subnets" {
 
 module "eks_cluster" {
   source  = "cloudposse/eks-cluster/aws"
-  version = "2.8.0"
+  version = "3.0.0"
 
   region                       = var.region
   vpc_id                       = module.vpc.vpc_id

--- a/examples/complete/variables-eks.tf
+++ b/examples/complete/variables-eks.tf
@@ -10,7 +10,7 @@ variable "availability_zones" {
 
 variable "kubernetes_version" {
   type        = string
-  default     = "1.17"
+  default     = "1.29"
   description = "Desired Kubernetes master version. If you do not specify a value, the latest available version is used"
 }
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -274,10 +274,15 @@ variable "postrender_binary_path" {
 ### EKS Addons
 variable "addons" {
   type = list(object({
-    addon_name               = string
-    addon_version            = string
-    resolve_conflicts        = string
-    service_account_role_arn = string
+    addon_name                  = string
+    addon_version               = optional(string, null)
+    configuration_values        = optional(string, null)
+    resolve_conflicts_on_create = optional(string, null)
+    resolve_conflicts_on_update = optional(string, null)
+    service_account_role_arn    = optional(string, null)
+    create_timeout              = optional(string, null)
+    update_timeout              = optional(string, null)
+    delete_timeout              = optional(string, null)
   }))
   description = "Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources"
   default     = []

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
     # Update these to reflect the actual requirements of your module
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.2"
+      version = "~> 2.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## what

This links to #77, this is a temporary fix as the current latest version of this provider 3.x is not currently compatible with this module

## why

The current latest vversion of hashicorp helm does not work with this module

## references

The breaking changes in the latest version of the module: https://github.com/hashicorp/terraform-provider-helm/releases/tag/v3.0.0