### PR TITLE
feat!: update to use `kubernetes_namespace_v1` resource

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -12,7 +12,7 @@ name = "helm"
 
 availability_zones = ["us-east-2a", "us-east-2b"]
 
-kubernetes_version = "1.26"
+kubernetes_version = "1.30"
 addons = [
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#vpc-cni-latest-available-version
   {

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -16,24 +16,27 @@ kubernetes_version = "1.26"
 addons = [
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#vpc-cni-latest-available-version
   {
-    addon_name               = "vpc-cni"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "vpc-cni"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
   {
-    addon_name               = "kube-proxy"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "kube-proxy"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
   {
-    addon_name               = "coredns"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "coredns"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
 ]
 

--- a/examples/complete/main-eks.tf
+++ b/examples/complete/main-eks.tf
@@ -64,7 +64,7 @@ module "subnets" {
 
 module "eks_cluster" {
   source  = "cloudposse/eks-cluster/aws"
-  version = "2.8.0"
+  version = "3.0.0"
 
   region                       = var.region
   vpc_id                       = module.vpc.vpc_id

--- a/examples/complete/main-eks.tf
+++ b/examples/complete/main-eks.tf
@@ -45,7 +45,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.3.0"
+  version = "2.4.1"
 
   availability_zones              = var.availability_zones
   vpc_id                          = module.vpc.vpc_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ data "aws_eks_cluster_auth" "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks_cluster.eks_cluster_endpoint
     token                  = data.aws_eks_cluster_auth.kubernetes.token
     cluster_ca_certificate = base64decode(module.eks_cluster.eks_cluster_certificate_authority_data)

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ data "aws_eks_cluster_auth" "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes = {
+  kubernetes {
     host                   = module.eks_cluster.eks_cluster_endpoint
     token                  = data.aws_eks_cluster_auth.kubernetes.token
     cluster_ca_certificate = base64decode(module.eks_cluster.eks_cluster_certificate_authority_data)

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -274,10 +274,12 @@ variable "postrender_binary_path" {
 ### EKS Addons
 variable "addons" {
   type = list(object({
-    addon_name               = string
-    addon_version            = string
-    resolve_conflicts        = string
-    service_account_role_arn = string
+    addon_name                  = string
+    addon_version               = optional(string, null)
+    configuration_values        = optional(string, null)
+    resolve_conflicts_on_create = optional(string, null)
+    resolve_conflicts_on_update = optional(string, null)
+    service_account_role_arn    = optional(string, null)
   }))
   description = "Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources"
   default     = []

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.2"
+      version = ">= 2.2, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 5.0.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ module "eks_iam_role" {
   depends_on = [module.eks_iam_policy]
 }
 
-resource "kubernetes_namespace" "default" {
+resource "kubernetes_namespace_v1" "default" {
   count = local.create_namespace_via_k8s ? 1 : 0
 
   metadata {
@@ -145,7 +145,7 @@ resource "helm_release" "this" {
 
   depends_on = [
     module.eks_iam_role,
-    kubernetes_namespace.default,
+    kubernetes_namespace_v1.default,
   ]
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
     # Update these to reflect the actual requirements of your module
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.2"
+      version = ">= 2.2, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Why

> [!CAUTION]
> This is a breaking change for existing deployments using `create_namespace_with_kubernetes = true`. Consumers must run a state move before applying:

The `helm-release` module uses the deprecated `kubernetes_namespace` resource, which produces warnings during plan and apply:

```console
Warning: Deprecated Resource

  with module.n8n.kubernetes_namespace.default,
  on .terraform/infra/modules/n8n/main.tf line 50, in resource "kubernetes_namespace" "default":
  50: resource "kubernetes_namespace" "default" {

Deprecated; use kubernetes_namespace_v1.
```

This resource will eventually be removed from the Kubernetes provider, making this a proactive fix to avoid future breakage.

## What

Replace `kubernetes_namespace` with `kubernetes_namespace_v1` in `main.tf`. The two resource types are schema-compatible, so no other code changes are needed.

```sh
terraform state mv \
  'module.<name>.kubernetes_namespace.default[0]' \
  'module.<name>.kubernetes_namespace_v1.default[0]'
```

Without the state move, Terraform will destroy and recreate the namespace, deleting all resources within it.

## References

- [Kubernetes Provider: `kubernetes_namespace` deprecation](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace)
- [Kubernetes Provider: `kubernetes_namespace_v1`](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1)
