### PR TITLE
chore: pin to v2 helm provider untill upstream PR is merged

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
     # Update these to reflect the actual requirements of your module
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.2"
+      version = "~> 2.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## what

* module automatically pulls v3.0 new released helm provider which module doesn't support yet

## why

* breaks moduel

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
