### PR TITLE
Update module for Helm provider v3

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -12,28 +12,31 @@ name = "helm"
 
 availability_zones = ["us-east-2a", "us-east-2b"]
 
-kubernetes_version = "1.26"
+kubernetes_version = "1.29"
 addons = [
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#vpc-cni-latest-available-version
   {
-    addon_name               = "vpc-cni"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "vpc-cni"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
   {
-    addon_name               = "kube-proxy"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "kube-proxy"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
   {
-    addon_name               = "coredns"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "coredns"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
 ]
 

--- a/examples/complete/main-eks.tf
+++ b/examples/complete/main-eks.tf
@@ -45,7 +45,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.3.0"
+  version = "2.4.2"
 
   availability_zones              = var.availability_zones
   vpc_id                          = module.vpc.vpc_id
@@ -64,7 +64,7 @@ module "subnets" {
 
 module "eks_cluster" {
   source  = "cloudposse/eks-cluster/aws"
-  version = "2.8.0"
+  version = "3.0.0"
 
   region                       = var.region
   vpc_id                       = module.vpc.vpc_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ data "aws_eks_cluster_auth" "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks_cluster.eks_cluster_endpoint
     token                  = data.aws_eks_cluster_auth.kubernetes.token
     cluster_ca_certificate = base64decode(module.eks_cluster.eks_cluster_certificate_authority_data)

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -274,10 +274,15 @@ variable "postrender_binary_path" {
 ### EKS Addons
 variable "addons" {
   type = list(object({
-    addon_name               = string
-    addon_version            = string
-    resolve_conflicts        = string
-    service_account_role_arn = string
+    addon_name                  = string
+    addon_version               = optional(string, null)
+    configuration_values        = optional(string, null)
+    resolve_conflicts_on_create = optional(string, null)
+    resolve_conflicts_on_update = optional(string, null)
+    service_account_role_arn    = optional(string, null)
+    create_timeout              = optional(string, null)
+    update_timeout              = optional(string, null)
+    delete_timeout              = optional(string, null)
   }))
   description = "Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources"
   default     = []

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,21 @@ locals {
   # Maintain backward compatibility with v0.6.0, use helm to create
   # the namespace if the new (with v0.7.0) variables are not used.
   create_namespace_via_helm = local.create_namespace && !local.create_namespace_via_k8s
+
+  set = concat(
+    var.set,
+    local.iam_role_enabled && var.service_account_role_arn_annotation_enabled ? [
+      {
+        name  = var.service_account_set_key_path
+        value = module.eks_iam_role.service_account_role_arn
+        type  = "string"
+      }
+    ] : []
+  )
+
+  postrender = var.postrender_binary_path != null ? {
+    binary_path = var.postrender_binary_path
+  } : null
 }
 
 module "eks_iam_policy" {
@@ -107,45 +122,12 @@ resource "helm_release" "this" {
   verify                     = var.verify
   wait                       = var.wait
   wait_for_jobs              = var.wait_for_jobs
-
-  dynamic "set" {
-    for_each = var.set
-    content {
-      name  = set.value["name"]
-      value = set.value["value"]
-      type  = set.value["type"]
-    }
-  }
-
-  dynamic "set_sensitive" {
-    for_each = var.set_sensitive
-    content {
-      name  = set_sensitive.value["name"]
-      value = set_sensitive.value["value"]
-      type  = set_sensitive.value["type"]
-    }
-  }
-
-  dynamic "set" {
-    for_each = local.iam_role_enabled && var.service_account_role_arn_annotation_enabled ? [module.eks_iam_role.service_account_role_arn] : []
-    content {
-      name  = var.service_account_set_key_path
-      value = set.value
-      type  = "string"
-    }
-  }
-
-  dynamic "postrender" {
-    for_each = var.postrender_binary_path != null ? [1] : []
-
-    content {
-      binary_path = var.postrender_binary_path
-    }
-  }
+  set                        = local.set
+  set_sensitive              = var.set_sensitive
+  postrender                 = local.postrender
 
   depends_on = [
     module.eks_iam_role,
     kubernetes_namespace.default,
   ]
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
     # Update these to reflect the actual requirements of your module
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.2"
+      version = ">= 3"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## what

- Updates the Helm provider requirement to `>= 3`
- Migrates `helm_release` `set`, `set_sensitive`, and `postrender` usage to Helm provider v3 syntax
- Updates the complete example Helm provider configuration to v3 object syntax
- Updates complete example module references required for validation with current providers

## why

- The Cloud Posse Terraform BATS provider-pinning check requires provider constraints to use `>=` constraints.
- Helm provider v3 changes nested block syntax, so the module needs code changes before it can safely allow v3.
- The complete example also needed current `dynamic-subnets` and `eks-cluster` module versions to validate with AWS provider v6.

## validation

- `terraform fmt -check -recursive`
- `terraform validate -no-color` in the root module with Helm provider v3.1.2
- `terraform validate -no-color` in `examples/complete` with Helm provider v3.1.2 and AWS provider v6.46.0

## references

- https://github.com/cloudposse/test-harness/blob/3684c2f7ffc3300adca0c129f84748b97743d3b3/test/terraform/provider-pinning.bats#L3
- https://registry.terraform.io/providers/hashicorp/helm/latest/docs/guides/v3-upgrade-guide